### PR TITLE
fix: ensure mcp flow tool names are human readable

### DIFF
--- a/packages/server/api/src/app/mcp/mcp-server/mcp-server.ts
+++ b/packages/server/api/src/app/mcp/mcp-server/mcp-server.ts
@@ -166,7 +166,8 @@ async function addFlowToServer(
     }
 
     const triggerSettings = populatedFlow.version.trigger.settings as McpTrigger
-    const toolName = mcpToolNaming.fixTool(mcpTool.flowId!, mcpTool.id, McpToolType.FLOW)
+    const flowToolName = mcpTool.flow ? mcpTool.flow.version.displayName : mcpTool.flowId!
+    const toolName = mcpToolNaming.fixTool(flowToolName, mcpTool.id, McpToolType.FLOW)
     const toolDescription = triggerSettings.input?.toolDescription
     const inputSchema = triggerSettings.input?.inputSchema
     const returnsResponse = triggerSettings.input?.returnsResponse


### PR DESCRIPTION
### What does this PR do?
- Currently, flow tool names are random UUIDs, make it human readable (albeit with underscores)
