### PR TITLE
fix: ensure consistent types for global oauth apps to cloud oauth type

### DIFF
--- a/packages/react-ui/src/features/connections/lib/oauth-apps-hooks.ts
+++ b/packages/react-ui/src/features/connections/lib/oauth-apps-hooks.ts
@@ -104,8 +104,14 @@ export const oauthAppsQueries = {
         //   : await oauthAppsApi.listCloudOAuthApps(edition);
 
         // Todo (Rupal): Ideally, we should use cloud auth and modify it to suit our needs but this will do. i.e. global oauth apps
-        const apps = await oauthAppsApi.listOAuthAppsCredentials({ limit: 10000, cursor: undefined});
-        const cloudApps = await oauthAppsApi.listGlobalOAuthAppsCredentials({ limit: 10000, cursor: undefined});
+        const apps = await oauthAppsApi.listOAuthAppsCredentials({
+          limit: 10000,
+          cursor: undefined,
+        });
+        const cloudApps = await oauthAppsApi.listGlobalOAuthAppsCredentials({
+          limit: 10000,
+          cursor: undefined,
+        });
 
         const appsMap: PieceToClientIdMap = {};
         // Object.keys(cloudApps).forEach((key) => {
@@ -115,13 +121,12 @@ export const oauthAppsQueries = {
         //   };
         // });
 
+        // Use global oauth apps as cloud apps
         cloudApps.data.forEach((app) => {
-          Object.keys(cloudApps).forEach((key) => {
-            appsMap[`${app.pieceName}-${AppConnectionType.CLOUD_OAUTH2}`] = {
-              type: AppConnectionType.CLOUD_OAUTH2,
-              clientId: app.clientId,
-            };
-          });
+          appsMap[`${app.pieceName}-${AppConnectionType.CLOUD_OAUTH2}`] = {
+            type: AppConnectionType.CLOUD_OAUTH2,
+            clientId: app.clientId,
+          };
         });
 
         apps.data.forEach((app) => {

--- a/packages/server/api/src/app/app-connection/app-connection-service/oauth2/services/global-oauth2-service.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/oauth2/services/global-oauth2-service.ts
@@ -3,7 +3,6 @@ import {
     AppConnectionType,
     CloudOAuth2ConnectionValue,
     isNil,
-    PlatformOAuth2ConnectionValue,
 } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { domainHelper } from '../../../../helper/domain-helper'
@@ -55,7 +54,7 @@ export const globalOAuth2Service = (log: FastifyBaseLogger) => ({
         projectId,
         platformId,
         connectionValue,
-    }: RefreshOAuth2Request<CloudOAuth2ConnectionValue>): Promise<PlatformOAuth2ConnectionValue> => {
+    }: RefreshOAuth2Request<CloudOAuth2ConnectionValue>): Promise<CloudOAuth2ConnectionValue> => {
         const oauth2App = await globalOAuthAppService.getWithSecret({ pieceName, clientId: connectionValue.client_id })
         const newValue = await credentialsOauth2Service(log).refresh({
             pieceName,
@@ -75,13 +74,12 @@ export const globalOAuth2Service = (log: FastifyBaseLogger) => ({
             access_token: newValue.access_token,
             claimed_at: newValue.claimed_at,
             refresh_token: newValue.refresh_token,
-            redirect_url: newValue.redirect_url,
             scope: newValue.scope,
             token_url: newValue.token_url,
             data: newValue.data,
             props: newValue.props,
             authorization_method: newValue.authorization_method,
-            type: AppConnectionType.PLATFORM_OAUTH2,
+            type: AppConnectionType.CLOUD_OAUTH2,
         }
     },
 })


### PR DESCRIPTION
### What does this PR do?
- Fix an issue where global oauth connections intermittently reverted to platform types causing refresh token issue
- Optimize piece to clientId map generation on UI
