### PR TITLE
fix: allow for auth header overrides when calling services

### DIFF
--- a/packages/react-ui/src/components/lib/botx-api.ts
+++ b/packages/react-ui/src/components/lib/botx-api.ts
@@ -21,7 +21,7 @@ export const botxApi = ({ BOTX_API_URL, ZERO_API_URL }: BotxApiParams) => ({
     return api.post<ChatBotxResponse>(
       `${BOTX_API_URL}/v1/chat/sse`,
       request,
-      null,
+      undefined,
       {
         Authorization: `Bearer ${authenticationSession.getBotxToken()}`,
       },
@@ -32,10 +32,11 @@ export const botxApi = ({ BOTX_API_URL, ZERO_API_URL }: BotxApiParams) => ({
     if (isNil(BOTX_API_URL)) return Promise.reject('invalid bot URL');
     return api.get<ChatBotxUserMessage[]>(
       `${BOTX_API_URL}/v1/chat`,
-      '',
       undefined,
       {
-        Authorization: `Bearer ${authenticationSession.getBotxToken()}`,
+        headers: {
+          Authorization: `Bearer ${authenticationSession.getBotxToken()}`,
+        },
       },
     );
   },

--- a/packages/react-ui/src/lib/api.ts
+++ b/packages/react-ui/src/lib/api.ts
@@ -64,12 +64,12 @@ function request<TResponse>(
     url: resolvedUrl,
     ...config,
     headers: {
-      ...config.headers,
       Authorization: getToken(
         unAuthenticated,
         isApWebsite,
         authenticationSession.getToken(),
       ),
+      ...config.headers,
     },
   })
     .then((response) =>
@@ -117,12 +117,7 @@ export const api = {
   },
   any: <TResponse>(url: string, config?: AxiosRequestConfig) =>
     request<TResponse>(url, config),
-  get: <TResponse>(
-    url: string,
-    query?: unknown,
-    config?: AxiosRequestConfig,
-    headers?: Record<string, string>,
-  ) =>
+  get: <TResponse>(url: string, query?: unknown, config?: AxiosRequestConfig) =>
     request<TResponse>(url, {
       params: query,
       paramsSerializer: (params) => {
@@ -131,7 +126,6 @@ export const api = {
         });
       },
       ...config,
-      headers: { ...headers },
     }),
   delete: <TResponse>(
     url: string,


### PR DESCRIPTION
### What does this PR do?
- Change order of applying authorization headers so that custom auth headers are allowed
- Change botx APIs to have minimal changes over upstream and follow axios practices properly (i.e. leverage axios request config)
