### PR TITLE
feat: enable invitation link

### DIFF
--- a/packages/server/api/src/app/user-invitations/user-invitation.service.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.service.ts
@@ -258,7 +258,7 @@ async function generateInvitationLink(userInvitation: UserInvitation, expireyInS
     })
 }
 const enrichWithInvitationLink = async (platform: Platform, userInvitation: UserInvitation, expireyInSeconds: number, log: FastifyBaseLogger) => {
-    // const invitationLink = await generateInvitationLink(userInvitation, expireyInSeconds)
+    const invitationLink = await generateInvitationLink(userInvitation, expireyInSeconds)
     // if (!smtpEmailSender(log).isSmtpConfigured(platform)) {
     //     return {
     //         ...userInvitation,
@@ -269,7 +269,11 @@ const enrichWithInvitationLink = async (platform: Platform, userInvitation: User
     //     userInvitation,
     //     invitationLink,
     // })
-    return userInvitation
+    // return userInvitation
+    return {
+        ...userInvitation,
+        link: invitationLink,
+    }
 }
 type ListUserParams = {
     platformId: string


### PR DESCRIPTION
### What does this PR do?
- Allow invitation request creations to return a invitation link that's active for 1 hour (this is needed for collaboration feature)
