### PR TITLE
feat: enable platform user invitations (DNM)

### DIFF
--- a/packages/react-ui/src/app/components/ap-dashboard-sidebar-header.tsx
+++ b/packages/react-ui/src/app/components/ap-dashboard-sidebar-header.tsx
@@ -28,10 +28,11 @@ const ApDashboardSidebarHeader = ({
   const { data: edition } = flagsHooks.useFlag<ApEdition>(ApFlagId.EDITION);
   const { embedState } = useEmbedding();
   const isInPlatformAdmin = window.location.pathname.includes('platform');
-  const showProjectSwitcher =
-    edition !== ApEdition.COMMUNITY &&
-    !embedState.isEmbedded &&
-    !isInPlatformAdmin;
+  // const showProjectSwitcher =
+  //   edition !== ApEdition.COMMUNITY &&
+  //   !embedState.isEmbedded &&
+  //   !isInPlatformAdmin;
+  const showProjectSwitcher = !embedState.isEmbedded && !isInPlatformAdmin;
   const defaultRoute = determineDefaultRoute(useAuthorization().checkAccess);
 
   return (

--- a/packages/react-ui/src/app/components/sidebar/index.tsx
+++ b/packages/react-ui/src/app/components/sidebar/index.tsx
@@ -214,13 +214,11 @@ export function SidebarComponent({
                   <SidebarGroup>
                     <SidebarGroupLabel>{t('Misc')}</SidebarGroupLabel>
                     <SidebarMenu>
-                      {isCloudPlatform && (
-                        <SidebarMenuItem>
-                          <SidebarMenuButton asChild>
-                            <SidebarPlatformAdminButton />
-                          </SidebarMenuButton>
-                        </SidebarMenuItem>
-                      )}
+                      <SidebarMenuItem>
+                        <SidebarMenuButton asChild>
+                          <SidebarPlatformAdminButton />
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
                       {showConnectionsLink && (
                         <SidebarMenuItem>
                           <SidebarMenuButton asChild>
@@ -240,10 +238,10 @@ export function SidebarComponent({
                 </ScrollArea>
               </SidebarContent>
               <SidebarFooter className="pb-4">
-                {/* <SidebarMenu>
+                <SidebarMenu>
                   <SidebarInviteUserButton />
                 </SidebarMenu>
-                <SidebarMenu>
+                {/* <SidebarMenu>
                   <HelpAndFeedback />
                 </SidebarMenu>
                 {showProjectUsage && (

--- a/packages/react-ui/src/features/team/component/invite-user-dialog.tsx
+++ b/packages/react-ui/src/features/team/component/invite-user-dialog.tsx
@@ -155,7 +155,7 @@ export const InviteUserDialog = ({ children }: { children?: ReactNode }) => {
       type: platform.plan.projectRolesEnabled
         ? InvitationType.PROJECT
         : InvitationType.PLATFORM,
-      platformRole: PlatformRole.ADMIN,
+      platformRole: PlatformRole.MEMBER,
       projectRole: roles?.[0]?.name,
     },
   });

--- a/packages/react-ui/src/features/team/component/platform-role-select.tsx
+++ b/packages/react-ui/src/features/team/component/platform-role-select.tsx
@@ -33,6 +33,9 @@ export const PlatformRoleSelect = ({ form }: PlatformRoleSelectProps) => {
               <SelectGroup>
                 <SelectLabel>{t('Platform Role')}</SelectLabel>
                 <SelectItem value={PlatformRole.ADMIN}>{t('Admin')}</SelectItem>
+                <SelectItem value={PlatformRole.MEMBER}>
+                  {t('Member')}
+                </SelectItem>
               </SelectGroup>
             </SelectContent>
           </Select>


### PR DESCRIPTION
### What does this PR do?
- Enable "user invitations" but to platform level
- This also enable multiple projects per platform as a pre-requisite to platform level collaboration
- Has 2 platform roles (Admin, Member). Both allows to change data but members cannot access admin page and therefore cannot create projects, send invitations or manage users from within
