### PR TITLE
feat: project roles

### DIFF
--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -84,6 +84,7 @@ import { pieceSyncService } from './pieces/piece-sync-service'
 import { platformModule } from './platform/platform.module'
 // import { projectHooks } from './project/project-hooks'
 import { projectModule } from './project/project-module'
+import { projectRoleModule } from './project-role/project-role.module'
 import { storeEntryModule } from './store-entry/store-entry.module'
 import { tablesModule } from './tables/tables.module'
 import { tagsModule } from './tags/tags-module'
@@ -247,6 +248,7 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
     await app.register(changelogModule)
     await app.register(agentModule)
     await app.register(todoActivityModule)
+    await app.register(projectRoleModule)
 
     app.get(
         '/redirect',

--- a/packages/server/api/src/app/database/database-connection.ts
+++ b/packages/server/api/src/app/database/database-connection.ts
@@ -227,4 +227,4 @@ export function APArrayContains<T>(
 }
 
 // Uncomment the below line when running `nx db-migration server-api --name=<MIGRATION_NAME>` and recomment it after the migration is generated
-export const exportedConnection = databaseConnection()
+// export const exportedConnection = databaseConnection()

--- a/packages/server/api/src/app/database/database-connection.ts
+++ b/packages/server/api/src/app/database/database-connection.ts
@@ -50,6 +50,7 @@ import { OAuthAppEntity } from '../oauth-apps/oauth-app.entity'
 import { PieceMetadataEntity } from '../pieces/piece-metadata-entity'
 import { PlatformEntity } from '../platform/platform.entity'
 import { ProjectEntity } from '../project/project-entity'
+import { ProjectRoleEntity } from '../project-role/project-role.entity'
 import { StoreEntryEntity } from '../store-entry/store-entry-entity'
 import { FieldEntity } from '../tables/field/field.entity'
 import { CellEntity } from '../tables/record/cell.entity'
@@ -112,6 +113,7 @@ function getEntities(): EntitySchema<unknown>[] {
         McpToolEntity,
         McpRunEntity,
         AIUsageEntity,
+        ProjectRoleEntity,
     ]
 
     switch (edition) {

--- a/packages/server/api/src/app/database/database-connection.ts
+++ b/packages/server/api/src/app/database/database-connection.ts
@@ -227,4 +227,4 @@ export function APArrayContains<T>(
 }
 
 // Uncomment the below line when running `nx db-migration server-api --name=<MIGRATION_NAME>` and recomment it after the migration is generated
-// export const exportedConnection = databaseConnection()
+export const exportedConnection = databaseConnection()

--- a/packages/server/api/src/app/database/migration/postgres/1752736911931-project-role.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1752736911931-project-role.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class ProjectRole1752736911931 implements MigrationInterface {
+    name = 'ProjectRole1752736911931'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE "project_role" (
+                "id" character varying(21) NOT NULL,
+                "created" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "updated" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "name" character varying NOT NULL,
+                "permissions" character varying array NOT NULL,
+                "platformId" character varying,
+                "type" character varying NOT NULL,
+                CONSTRAINT "PK_5974798305ac81d4a7d23ab1c6a" PRIMARY KEY ("id")
+            )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP TABLE "project_role"
+        `)
+    }
+}

--- a/packages/server/api/src/app/database/migration/postgres/1752744019509-default-project-role.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1752744019509-default-project-role.ts
@@ -1,0 +1,42 @@
+import { apId, ProjectRole, RoleType } from '@activepieces/shared'
+import dayjs from 'dayjs'
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class DefaultProjectRole1752744019509 implements MigrationInterface {
+    name = 'DefaultProjectRole1752744019509'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const ts = dayjs().toISOString()
+        const defaultProjectMemberRole: ProjectRole = {
+            id: apId(),
+            name: 'Member',
+            permissions: [],
+            platformId: undefined,
+            type: RoleType.DEFAULT,
+            created: ts,
+            updated: ts,
+        }
+
+        await queryRunner.query(
+            `INSERT INTO "project_role" (id, name, permissions, type, "platformId", created, updated)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)
+            `,
+            [
+                defaultProjectMemberRole.id,
+                defaultProjectMemberRole.name,
+                defaultProjectMemberRole.permissions,
+                defaultProjectMemberRole.type,
+                defaultProjectMemberRole.platformId,
+                defaultProjectMemberRole.created,
+                defaultProjectMemberRole.updated,
+            ],
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            'DELETE FROM "project_role" WHERE type = $1 AND name = $2',
+            [RoleType.DEFAULT, 'Member']
+        )
+    }
+}

--- a/packages/server/api/src/app/database/migration/postgres/1752746415961-add-project-role-invitation.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1752746415961-add-project-role-invitation.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddProjectRoleInvitation1752746415961 implements MigrationInterface {
+    name = 'AddProjectRoleInvitation1752746415961'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "user_invitation"
+            ADD "projectRoleId" character varying
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "user_invitation"
+            ADD CONSTRAINT "fk_user_invitation_project_role_id" FOREIGN KEY ("projectRoleId") REFERENCES "project_role"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "user_invitation" DROP CONSTRAINT "fk_user_invitation_project_role_id"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "user_invitation" DROP COLUMN "projectRoleId"
+        `)
+    }
+}

--- a/packages/server/api/src/app/database/migration/sqlite/1752743014852-project-role.ts
+++ b/packages/server/api/src/app/database/migration/sqlite/1752743014852-project-role.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class ProjectRole1752743014852 implements MigrationInterface {
+    name = 'ProjectRole1752743014852'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE "project_role" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "name" varchar NOT NULL,
+                "permissions" text NOT NULL,
+                "platformId" varchar,
+                "type" varchar NOT NULL
+            )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP TABLE "project_role"
+        `)
+    }
+}

--- a/packages/server/api/src/app/database/migration/sqlite/1752746475364-add-project-role-invitation.ts
+++ b/packages/server/api/src/app/database/migration/sqlite/1752746475364-add-project-role-invitation.ts
@@ -1,0 +1,221 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddProjectRoleInvitation1752746475364 implements MigrationInterface {
+    name = 'AddProjectRoleInvitation1752746475364'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX "idx_user_invitation_email_platform_project"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "temporary_user_invitation" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "platformId" varchar NOT NULL,
+                "type" varchar NOT NULL,
+                "platformRole" varchar,
+                "email" varchar NOT NULL,
+                "projectId" varchar,
+                "status" varchar NOT NULL,
+                "projectRoleId" varchar,
+                CONSTRAINT "fk_user_invitation_project_id" FOREIGN KEY ("projectId") REFERENCES "project" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "temporary_user_invitation"(
+                    "id",
+                    "created",
+                    "updated",
+                    "platformId",
+                    "type",
+                    "platformRole",
+                    "email",
+                    "projectId",
+                    "status"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "platformId",
+                "type",
+                "platformRole",
+                "email",
+                "projectId",
+                "status"
+            FROM "user_invitation"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "user_invitation"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "temporary_user_invitation"
+                RENAME TO "user_invitation"
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_invitation_email_platform_project" ON "user_invitation" ("email", "platformId", "projectId")
+        `)
+
+        await queryRunner.query(`
+            DROP INDEX "idx_user_invitation_email_platform_project"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "temporary_user_invitation" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "platformId" varchar NOT NULL,
+                "type" varchar NOT NULL,
+                "platformRole" varchar,
+                "email" varchar NOT NULL,
+                "projectId" varchar,
+                "status" varchar NOT NULL,
+                "projectRoleId" varchar,
+                CONSTRAINT "fk_user_invitation_project_id" FOREIGN KEY ("projectId") REFERENCES "project" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+                CONSTRAINT "fk_user_invitation_project_role_id" FOREIGN KEY ("projectRoleId") REFERENCES "project_role" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "temporary_user_invitation"(
+                    "id",
+                    "created",
+                    "updated",
+                    "platformId",
+                    "type",
+                    "platformRole",
+                    "email",
+                    "projectId",
+                    "status",
+                    "projectRoleId"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "platformId",
+                "type",
+                "platformRole",
+                "email",
+                "projectId",
+                "status",
+                "projectRoleId"
+            FROM "user_invitation"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "user_invitation"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "temporary_user_invitation"
+                RENAME TO "user_invitation"
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_invitation_email_platform_project" ON "user_invitation" ("email", "platformId", "projectId")
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX "idx_user_invitation_email_platform_project"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "user_invitation"
+                RENAME TO "temporary_user_invitation"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "user_invitation" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "platformId" varchar NOT NULL,
+                "type" varchar NOT NULL,
+                "platformRole" varchar,
+                "email" varchar NOT NULL,
+                "projectId" varchar,
+                "status" varchar NOT NULL,
+                "projectRoleId" varchar,
+                CONSTRAINT "fk_user_invitation_project_id" FOREIGN KEY ("projectId") REFERENCES "project" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "user_invitation"(
+                    "id",
+                    "created",
+                    "updated",
+                    "platformId",
+                    "type",
+                    "platformRole",
+                    "email",
+                    "projectId",
+                    "status",
+                    "projectRoleId"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "platformId",
+                "type",
+                "platformRole",
+                "email",
+                "projectId",
+                "status",
+                "projectRoleId"
+            FROM "temporary_user_invitation"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "temporary_user_invitation"
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_invitation_email_platform_project" ON "user_invitation" ("email", "platformId", "projectId")
+        `)
+
+        await queryRunner.query(`
+            DROP INDEX "idx_user_invitation_email_platform_project"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "user_invitation"
+                RENAME TO "temporary_user_invitation"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "user_invitation" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "platformId" varchar NOT NULL,
+                "type" varchar NOT NULL,
+                "platformRole" varchar,
+                "email" varchar NOT NULL,
+                "projectId" varchar,
+                "status" varchar NOT NULL,
+                CONSTRAINT "fk_user_invitation_project_id" FOREIGN KEY ("projectId") REFERENCES "project" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "user_invitation"(
+                    "id",
+                    "created",
+                    "updated",
+                    "platformId",
+                    "type",
+                    "platformRole",
+                    "email",
+                    "projectId",
+                    "status"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "platformId",
+                "type",
+                "platformRole",
+                "email",
+                "projectId",
+                "status"
+            FROM "temporary_user_invitation"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "temporary_user_invitation"
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_invitation_email_platform_project" ON "user_invitation" ("email", "platformId", "projectId")
+        `)
+    }
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -58,6 +58,8 @@ import { RevertTodoActivties1751217652277 } from './migration/postgres/175121765
 import { RemoveTerminationReason1751728035816 } from './migration/postgres/1751728035816-RemoveTerminationReason'
 import { AddFlowVersionToIssue1751927222122 } from './migration/postgres/1751927222122-AddFlowVersionToIssue'
 import { AddIndexForSchemaVersionInFlowVersion1752151941009 } from './migration/postgres/1752151941009-AddIndexForSchemaVersionInFlowVersion'
+import { ProjectRole1752736911931 } from './migration/postgres/1752736911931-project-role'
+import { DefaultProjectRole1752744019509 } from './migration/postgres/1752744019509-default-project-role'
 
 
 const getSslConfig = (): boolean | TlsOptions => {
@@ -72,6 +74,8 @@ const getSslConfig = (): boolean | TlsOptions => {
 
 const getMigrations = (): (new () => MigrationInterface)[] => {
     const commonMigration: (new () => MigrationInterface)[] = [
+        DefaultProjectRole1752744019509,
+        ProjectRole1752736911931,
         AddIndexForSchemaVersionInFlowVersion1752151941009,
         AddFlowVersionToIssue1751927222122,
         AddPlatformIdToAiUsage1750526457504,

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -60,6 +60,7 @@ import { AddFlowVersionToIssue1751927222122 } from './migration/postgres/1751927
 import { AddIndexForSchemaVersionInFlowVersion1752151941009 } from './migration/postgres/1752151941009-AddIndexForSchemaVersionInFlowVersion'
 import { ProjectRole1752736911931 } from './migration/postgres/1752736911931-project-role'
 import { DefaultProjectRole1752744019509 } from './migration/postgres/1752744019509-default-project-role'
+import { AddProjectRoleInvitation1752746415961 } from './migration/postgres/1752746415961-add-project-role-invitation'
 
 
 const getSslConfig = (): boolean | TlsOptions => {
@@ -74,6 +75,7 @@ const getSslConfig = (): boolean | TlsOptions => {
 
 const getMigrations = (): (new () => MigrationInterface)[] => {
     const commonMigration: (new () => MigrationInterface)[] = [
+        AddProjectRoleInvitation1752746415961,
         DefaultProjectRole1752744019509,
         ProjectRole1752736911931,
         AddIndexForSchemaVersionInFlowVersion1752151941009,

--- a/packages/server/api/src/app/database/sqlite-connection.ts
+++ b/packages/server/api/src/app/database/sqlite-connection.ts
@@ -51,6 +51,7 @@ import { AddPlatformIdToAIUsageSqlite1751475726665 } from './migration/sqlite/17
 import { RemoveTerminationReasonSqlite1751727630516 } from './migration/sqlite/1751727630516-RemoveTerminationReasonSqlite'
 import { AddFlowVersionToIssueSqlite1751927149586 } from './migration/sqlite/1751927149586-AddFlowVersionToIssueSqlite'
 import { AddIndexForSchemaVersionInFlowVersionSqlite1752152069517 } from './migration/sqlite/1752152069517-AddIndexForSchemaVersionInFlowVersionSqlite'
+import { ProjectRole1752743014852 } from './migration/sqlite/1752743014852-project-role'
 
 const getSqliteDatabaseFilePath = (): string => {
     const apConfigDirectoryPath = system.getOrThrow(AppSystemProp.CONFIG_PATH)
@@ -73,6 +74,7 @@ const getSqliteDatabase = (): string => {
 
 const getMigrations = (): (new () => MigrationInterface)[] => {
     const communityMigrations: (new () => MigrationInterface)[] = [
+        ProjectRole1752743014852,
         AddIndexForSchemaVersionInFlowVersionSqlite1752152069517,
         AddFlowVersionToIssueSqlite1751927149586,
         RevertTodoActivtiesSqlite1751217307674,

--- a/packages/server/api/src/app/database/sqlite-connection.ts
+++ b/packages/server/api/src/app/database/sqlite-connection.ts
@@ -52,6 +52,7 @@ import { RemoveTerminationReasonSqlite1751727630516 } from './migration/sqlite/1
 import { AddFlowVersionToIssueSqlite1751927149586 } from './migration/sqlite/1751927149586-AddFlowVersionToIssueSqlite'
 import { AddIndexForSchemaVersionInFlowVersionSqlite1752152069517 } from './migration/sqlite/1752152069517-AddIndexForSchemaVersionInFlowVersionSqlite'
 import { ProjectRole1752743014852 } from './migration/sqlite/1752743014852-project-role'
+import { AddProjectRoleInvitation1752746475364 } from './migration/sqlite/1752746475364-add-project-role-invitation'
 
 const getSqliteDatabaseFilePath = (): string => {
     const apConfigDirectoryPath = system.getOrThrow(AppSystemProp.CONFIG_PATH)
@@ -74,6 +75,7 @@ const getSqliteDatabase = (): string => {
 
 const getMigrations = (): (new () => MigrationInterface)[] => {
     const communityMigrations: (new () => MigrationInterface)[] = [
+        AddProjectRoleInvitation1752746475364,
         ProjectRole1752743014852,
         AddIndexForSchemaVersionInFlowVersionSqlite1752152069517,
         AddFlowVersionToIssueSqlite1751927149586,

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -49,7 +49,7 @@ const DEFAULT_PLAN = {
     manageTemplatesEnabled: true,
     customAppearanceEnabled: false,
     manageProjectsEnabled: false,
-    projectRolesEnabled: false,
+    projectRolesEnabled: true,
     customDomainsEnabled: false,
     apiKeysEnabled: false,
     alertsEnabled: false,

--- a/packages/server/api/src/app/project-role/project-role.entity.ts
+++ b/packages/server/api/src/app/project-role/project-role.entity.ts
@@ -1,0 +1,31 @@
+import { ApId, ProjectRole } from '@activepieces/shared'
+import { EntitySchema } from 'typeorm'
+import { ARRAY_COLUMN_TYPE, BaseColumnSchemaPart, isPostgres } from '../database/database-common'
+
+export type ProjectRoleSchema = ProjectRole & {
+    platformId: ApId
+}
+
+export const ProjectRoleEntity = new EntitySchema<ProjectRoleSchema>({
+    name: 'project_role',
+    columns: {
+        ...BaseColumnSchemaPart,
+        name: {
+            type: String,
+            nullable: false,
+        },
+        permissions: {
+            type: ARRAY_COLUMN_TYPE,
+            array: isPostgres(),
+            nullable: false,
+        },
+        platformId: {
+            type: String,
+            nullable: true,
+        },
+        type: {
+            type: String,
+            nullable: false,
+        },
+    },
+})

--- a/packages/server/api/src/app/project-role/project-role.module.ts
+++ b/packages/server/api/src/app/project-role/project-role.module.ts
@@ -1,0 +1,90 @@
+import { ApId, ProjectRole, SeekPage, UpdateProjectRoleRequestBody } from '@activepieces/shared'
+import { FastifyPluginAsyncTypebox, Type } from '@fastify/type-provider-typebox'
+import { StatusCodes } from 'http-status-codes'
+import { projectRoleService } from './project-role.service'
+
+const ListProjectRolesRequest = {
+    config: {},
+    schema: {
+        tags: ['project-role'],
+        response: {
+            [StatusCodes.OK]: SeekPage(ProjectRole),
+        }
+    }
+}
+
+const GetProjectRoleRequest = {
+    schema: {
+        tags: ['project-role'],
+        params: Type.Object({
+            id: ApId,
+        }),
+    },
+}
+
+const UpdateProjectRoleRequest = {
+    schema: {
+        body: UpdateProjectRoleRequestBody,
+        params: Type.Object({
+            id: ApId,
+        }),
+        response: {
+            [StatusCodes.OK]: ProjectRole,
+        },
+    },
+}
+
+const DeleteProjectRoleRequest = {
+    schema: {
+        params: Type.Object({
+            name: Type.String(),
+        }),
+        response: {
+            [StatusCodes.NO_CONTENT]: Type.Null(),
+        },
+    },
+}
+
+export const projectRoleModule: FastifyPluginAsyncTypebox = async (app) => {
+    await app.register(projectRoleController, { prefix: '/v1/project-roles' })
+}
+
+const projectRoleController: FastifyPluginAsyncTypebox = async (app) => {
+    app.get('/', ListProjectRolesRequest, async (request) => {
+        return projectRoleService.list({
+            platformId: request.principal.platform.id,
+        })
+    })
+
+    app.get('/:id', GetProjectRoleRequest, async (req) => {
+        return projectRoleService.getById({
+            id: req.params.id,
+        })
+    })
+
+    app.get('/:id/project-members', async (req, reply) => {
+        // todo(Rupal): Implement this later
+        await reply.status(200).send([])
+    })
+
+    app.post('/:id', UpdateProjectRoleRequest, async (req) => {
+        const projectRole = await projectRoleService.update({
+            id: req.params.id,
+            platformId: req.principal.platform.id,
+            name: req.body.name,
+            permissions: req.body.permissions,
+        })
+        return projectRole
+    })
+
+    app.delete('/:name', DeleteProjectRoleRequest, async (req) => {
+        await projectRoleService.getByNameAndPlatformOrThrow({
+            name: req.params.name,
+            platformId: req.principal.platform.id,
+        })
+        return projectRoleService.delete({
+            name: req.params.name,
+            platformId: req.principal.platform.id,
+        })
+    })
+}

--- a/packages/server/api/src/app/project-role/project-role.service.ts
+++ b/packages/server/api/src/app/project-role/project-role.service.ts
@@ -1,0 +1,104 @@
+import { ActivepiecesError, ApId, CreateProjectRoleRequestBody, ErrorCode, isNil, ProjectRole, RoleType, SeekPage } from '@activepieces/shared'
+import { Brackets } from 'typeorm'
+import { repoFactory } from '../core/db/repo-factory'
+import { ProjectRoleEntity } from './project-role.entity'
+
+
+export const projectRoleRepo = repoFactory(ProjectRoleEntity)
+
+export const projectRoleService = {
+    async getById({ id }: GetByIdParams): Promise<ProjectRole> {
+        const projectRole = await projectRoleRepo().findOneBy({ id })
+        if (isNil(projectRole)) {
+            throw new ActivepiecesError({
+                code: ErrorCode.ENTITY_NOT_FOUND,
+                params: { entityType: 'project_role', entityId: id, message: 'Project role not found' },
+            })
+        }
+        return projectRole
+    },
+    async getByNameAndPlatform({ name, platformId }: GetByNameParams): Promise<ProjectRole | null> {
+        return projectRoleRepo()
+            .createQueryBuilder('projectRole')
+            .where('LOWER(projectRole.name) = LOWER(:name)', { name })
+            .andWhere(new Brackets(qb => {
+                qb.where('projectRole.platformId = :platformId', { platformId })
+                    .orWhere('projectRole.type = :defaultType', { defaultType: RoleType.DEFAULT })
+            }))
+            .getOne()
+    },
+    async getByNameAndPlatformOrThrow({ name, platformId }: GetByNameParams): Promise<ProjectRole> {
+        const projectRole = await this.getByNameAndPlatform({ name, platformId })
+        if (isNil(projectRole)) {
+            throw new ActivepiecesError({
+                code: ErrorCode.ENTITY_NOT_FOUND,
+                params: { entityType: 'project_role', entityId: name, message: 'Project role not found' },
+            })
+        }
+        return projectRole
+    },
+    async list({ platformId }: ListParams): Promise<SeekPage<ProjectRole>> {
+        // Return roles either for the given platform OR globally defined default roles
+        const projectRoles = await projectRoleRepo().find({
+            where: [
+                { platformId },
+                { type: RoleType.DEFAULT },
+            ],
+            order: { created: 'ASC' },
+        })
+
+        // UI expects a paginated response format
+        return {
+            data: projectRoles,
+            next: null,
+            previous: null
+        }
+    },
+    async create(_params: CreateParams): Promise<void> {
+        throw new ActivepiecesError({
+            code: ErrorCode.FEATURE_DISABLED,
+            params: { message: 'Cannot create project role' },
+        })
+    },
+    async update(_params: UpdateParams): Promise<void> {
+        throw new ActivepiecesError({
+            code: ErrorCode.FEATURE_DISABLED,
+            params: { message: 'Cannot update project role' },
+        })
+    },
+    async delete(_params: DeleteParams): Promise<void> {
+        throw new ActivepiecesError({
+            code: ErrorCode.FEATURE_DISABLED,
+            params: { message: 'Cannot delete project role' },
+        })
+    },
+}
+
+type CreateParams = CreateProjectRoleRequestBody & {
+    platformId: ApId
+}
+
+type UpdateParams = {
+    id: ApId
+    platformId: ApId
+    name: string | undefined
+    permissions: string[] | undefined
+}
+
+type ListParams = {
+    platformId: ApId
+}
+
+type DeleteParams = {
+    name: ApId
+    platformId: ApId
+}
+
+type GetByNameParams = {
+    name: string
+    platformId: ApId
+}
+
+type GetByIdParams = {
+    id: ApId
+}

--- a/packages/server/api/src/app/user-invitations/user-invitation.entity.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.entity.ts
@@ -4,7 +4,7 @@ import { BaseColumnSchemaPart } from '../database/database-common'
 
 type UserInvitationSchema = UserInvitation & {
     project?: Project
-    // projectRole?: ProjectRole
+    projectRole?: ProjectRole
 }
 export const UserInvitationEntity = new EntitySchema<UserInvitationSchema>({
     name: 'user_invitation',
@@ -33,10 +33,10 @@ export const UserInvitationEntity = new EntitySchema<UserInvitationSchema>({
             type: String,
             nullable: false,
         },
-        // projectRoleId: {
-        //     type: String,
-        //     nullable: true,
-        // },
+        projectRoleId: {
+            type: String,
+            nullable: true,
+        },
     },
     indices: [
         {
@@ -56,16 +56,16 @@ export const UserInvitationEntity = new EntitySchema<UserInvitationSchema>({
                 foreignKeyConstraintName: 'fk_user_invitation_project_id',
             },
         },
-        // projectRole: {
-        //     type: 'many-to-one',
-        //     target: 'project_role',
-        //     cascade: true,
-        //     onDelete: 'CASCADE',
-        //     joinColumn: {
-        //         name: 'projectRoleId',
-        //         referencedColumnName: 'id',
-        //         foreignKeyConstraintName: 'fk_user_invitation_project_role_id',
-        //     },
-        // },
+        projectRole: {
+            type: 'many-to-one',
+            target: 'project_role',
+            cascade: true,
+            onDelete: 'CASCADE',
+            joinColumn: {
+                name: 'projectRoleId',
+                referencedColumnName: 'id',
+                foreignKeyConstraintName: 'fk_user_invitation_project_role_id',
+            },
+        },
     },
 })

--- a/packages/server/api/src/app/user-invitations/user-invitation.module.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.module.ts
@@ -27,6 +27,7 @@ import { StatusCodes } from 'http-status-codes'
 // import { PlatformPlanHelper } from '../ee/platform/platform-plan/platform-plan-helper'
 // import { projectRoleService } from '../ee/projects/project-role/project-role.service'
 import { projectService } from '../project/project-service'
+import { projectRoleService } from '../project-role/project-role.service'
 import { userInvitationsService } from './user-invitation.service'
 
 export const invitationModule: FastifyPluginAsyncTypebox = async (app) => {
@@ -119,14 +120,12 @@ const getProjectRoleAndAssertIfFound = async (platformId: string, request: SendU
     if (type === InvitationType.PLATFORM) {
         return null
     }
-    // const projectRoleName = request.projectRole
-
-    // const projectRole = await projectRoleService.getOneOrThrow({
-    //     name: projectRoleName,
-    //     platformId,
-    // })
-    // return projectRole
-    return null
+    const projectRoleName = request.projectRole
+    const projectRole = await projectRoleService.getByNameAndPlatformOrThrow({
+        name: projectRoleName,
+        platformId,
+    })
+    return projectRole
 }
 
 const getProjectIdAndAssertPermission = async (app: FastifyInstance, request: FastifyRequest, reply: FastifyReply, requestQuery: ListUserInvitationsRequest): Promise<string | null> => {

--- a/packages/server/api/src/app/user-invitations/user-invitation.service.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.service.ts
@@ -14,6 +14,7 @@ import { buildPaginator } from '../helper/pagination/build-paginator'
 import { paginationHelper } from '../helper/pagination/pagination-utils'
 import { platformService } from '../platform/platform.service'
 import { projectService } from '../project/project-service'
+import { projectRoleService } from '../project-role/project-role.service'
 import { userService } from '../user/user-service'
 import { UserInvitationEntity } from './user-invitation.entity'
 
@@ -155,7 +156,9 @@ export const userInvitationsService = (log: FastifyBaseLogger) => ({
                 // projectRole: !isNil(invitation.projectRoleId) ? await projectRoleService.getOneOrThrowById({
                 //     id: invitation.projectRoleId,
                 // }) : null,
-                projectRole: null,
+                projectRole: invitation.projectRoleId ? await projectRoleService.getById({
+                    id: invitation.projectRoleId,
+                }) : null,
                 ...invitation,
             }
         }))


### PR DESCRIPTION
### What does this PR do?
- Add "project roles" feature that mimics the upstream ee roles but bypasses all fine grain access checks (as we don't need)
- Modified "user invitations" to now support storing projectRoleId (disabled previously due to ee limitation)
- Enabled on backend but hidden on UI (need project member feature)

Notes
- SQLite DB option doesn't seed with default roles