### PR TITLE
fix: add auth bootstrap hoc to persist token cleanly

### DIFF
--- a/packages/react-ui/src/app/routes/sign-in/index.tsx
+++ b/packages/react-ui/src/app/routes/sign-in/index.tsx
@@ -1,11 +1,14 @@
 import { FullLogo } from '@/components/ui/full-logo';
+import { AuthBootstrap } from '@/features/authentication/components/auth-bootstrap';
 import { AuthFormTemplate } from '@/features/authentication/components/auth-form-template';
 
 const SignInPage: React.FC = () => {
   return (
     <div className="mx-auto flex h-screen flex-col items-center justify-center gap-2">
       <FullLogo />
-      <AuthFormTemplate form={'signin'} />
+      <AuthBootstrap>
+        <AuthFormTemplate form={'signin'} />
+      </AuthBootstrap>
     </div>
   );
 };

--- a/packages/react-ui/src/app/routes/sign-up/index.tsx
+++ b/packages/react-ui/src/app/routes/sign-up/index.tsx
@@ -1,11 +1,14 @@
 import { FullLogo } from '@/components/ui/full-logo';
+import { AuthBootstrap } from '@/features/authentication/components/auth-bootstrap';
 import { AuthFormTemplate } from '@/features/authentication/components/auth-form-template';
 
 const SignUpPage: React.FC = () => {
   return (
     <div className="mx-auto flex h-screen flex-col items-center justify-center gap-2">
       <FullLogo />
-      <AuthFormTemplate form={'signup'} />
+      <AuthBootstrap>
+        <AuthFormTemplate form={'signup'} />
+      </AuthBootstrap>
     </div>
   );
 };

--- a/packages/react-ui/src/features/authentication/components/auth-bootstrap.tsx
+++ b/packages/react-ui/src/features/authentication/components/auth-bootstrap.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { authenticationSession } from '@/lib/authentication-session';
+import { useRedirectAfterLogin } from '@/lib/navigation-utils';
+
+/*
+This higher order component wraps AuthFormTemplate to allow token persistence when token is passed
+as a query parameter in the sign in endpoint.
+*/
+export const AuthBootstrap = ({ children }: { children: React.ReactNode }) => {
+  const location = useLocation();
+  const redirectAfterLogin = useRedirectAfterLogin();
+
+  const searchParams = new URLSearchParams(location.search);
+  const tokenFromUrl = searchParams.get('token');
+
+  useEffect(() => {
+    if (tokenFromUrl) {
+      authenticationSession.saveToken(tokenFromUrl);
+    }
+  }, [tokenFromUrl]);
+
+  useEffect(() => {
+    // Only redirect if token is present
+    if (authenticationSession.getToken()) {
+      redirectAfterLogin();
+    }
+  }, [redirectAfterLogin]);
+
+  return children;
+};


### PR DESCRIPTION
### What does this PR do?
- Add a HOC that allows storing the token from the query param to local storage before rendering the main sign-in/sign-up pages
