### PR TITLE
chore: bump promptx agent version

### DIFF
--- a/packages/pieces/community/promptx-agent/package.json
+++ b/packages/pieces/community/promptx-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avalant/piece-promptx-agent",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts"


### PR DESCRIPTION
### What does this PR do?
- As the title says, needed to republish to npm as previous version dependencies were faulty
