### PR TITLE
feat: integrate smtp email service via sendgrid

### DIFF
--- a/packages/server/api/src/app/email/email.service.ts
+++ b/packages/server/api/src/app/email/email.service.ts
@@ -1,0 +1,44 @@
+import { assertNotNullOrUndefined, InvitationType, UserInvitation, UserInvitationWithLink } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { platformService } from '../platform/platform.service'
+import { projectService } from '../project/project-service'
+import { projectRoleService } from '../project-role/project-role.service'
+import { emailSender } from './sender'
+
+export const emailService = (log: FastifyBaseLogger) => ({
+    async sendInvitation(invitation: UserInvitationWithLink): Promise<void> {
+        const { email, platformId } = invitation
+        const name = await getEntityNameForInvitation(invitation)
+        await emailSender(log).send({
+            emails: [email],
+            platformId,
+            templateData: {
+                name: 'invitation-email',
+                vars: {
+                    projectOrPlatformName: name,
+                    invitationLink: invitation.link!,
+                },
+            },
+        })
+    },
+})
+
+async function getEntityNameForInvitation(userInvitation: UserInvitation): Promise<string> {
+    switch (userInvitation.type) {
+        case InvitationType.PLATFORM: {
+            const platform = await platformService.getOneOrThrow(userInvitation.platformId)
+            assertNotNullOrUndefined(userInvitation.platformRole, 'platformRole')
+            return platform.name
+        }
+        case InvitationType.PROJECT: {
+            assertNotNullOrUndefined(userInvitation.projectId, 'projectId')
+            assertNotNullOrUndefined(userInvitation.projectRoleId, 'projectRoleId')
+            // check if role is present or throw
+            await projectRoleService.getById({
+                id: userInvitation.projectRoleId,
+            })
+            const project = await projectService.getOneOrThrow(userInvitation.projectId)
+            return project.displayName
+        }
+    }
+}

--- a/packages/server/api/src/app/email/sender/dummy.ts
+++ b/packages/server/api/src/app/email/sender/dummy.ts
@@ -1,0 +1,15 @@
+import { FastifyBaseLogger } from 'fastify'
+import { EmailSender } from '.'
+
+export const dummyEmailSender = (log: FastifyBaseLogger): EmailSender => {
+    return {
+        async send({ emails, platformId, templateData }): Promise<void> {
+            log.debug({
+                name: 'DummyEmailSender#send',
+                emails,
+                platformId,
+                templateData,
+            })
+        },
+    }
+}

--- a/packages/server/api/src/app/email/sender/index.ts
+++ b/packages/server/api/src/app/email/sender/index.ts
@@ -1,0 +1,40 @@
+import { AppSystemProp } from '@activepieces/server-shared'
+import { ApEnvironment } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { system } from '../../helper/system/system'
+import { dummyEmailSender } from './dummy'
+import { smtpEmailSender } from './smtp'
+
+type BaseEmailTemplateData<Name extends string, Vars extends Record<string, string>> = {
+    name: Name
+    vars: Vars
+}
+
+type InvitationEmailTemplateData = BaseEmailTemplateData<'invitation-email', {
+    projectOrPlatformName: string
+    invitationLink: string
+}>
+
+export type EmailTemplateData = InvitationEmailTemplateData
+
+type SendEmailParams = {
+    emails: string[]
+    platformId: string | undefined
+    templateData: EmailTemplateData
+}
+
+export type EmailSender = {
+    send: (args: SendEmailParams) => Promise<void>
+}
+
+const getEmailSender = (log: FastifyBaseLogger): EmailSender => {
+    const env = system.get(AppSystemProp.ENVIRONMENT)
+
+    if (env === ApEnvironment.PRODUCTION) {
+        return smtpEmailSender(log)
+    }
+
+    return dummyEmailSender(log)
+}
+
+export const emailSender = (log: FastifyBaseLogger): EmailSender => getEmailSender(log)

--- a/packages/server/api/src/app/email/sender/smtp.ts
+++ b/packages/server/api/src/app/email/sender/smtp.ts
@@ -1,0 +1,94 @@
+import { readFile } from 'node:fs/promises'
+import { AppSystemProp } from '@activepieces/server-shared'
+import { isNil, Platform, SMTPInformation } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import Mustache from 'mustache'
+import nodemailer, { Transporter } from 'nodemailer'
+import { defaultTheme } from '../../flags/theme'
+import { system } from '../../helper/system/system'
+import { platformService } from '../../platform/platform.service'
+import { EmailSender, EmailTemplateData } from '.'
+
+
+type SMTPEmailSender = EmailSender & {
+    isSystemSmtpConfigured: () => boolean
+}
+
+export const smtpEmailSender = (log: FastifyBaseLogger): SMTPEmailSender => {
+    return {
+        async send({ emails, platformId, templateData }): Promise<void> {
+            if (!smtpEmailSender(log).isSystemSmtpConfigured()) {
+                log.error('SMTP is not configured for sending emails')
+                return
+            }
+
+            const platform = await getPlatform(platformId)
+            const emailSubject = getEmailSubject(templateData.name, templateData.vars)
+            const senderName = platform?.smtp?.senderName ?? system.get(AppSystemProp.SMTP_SENDER_NAME)
+            const senderEmail = platform?.smtp?.senderEmail ?? system.get(AppSystemProp.SMTP_SENDER_EMAIL)
+
+            const emailBody = await renderEmailBody({
+                platform,
+                templateData,
+            })
+
+            const smtpClient = initSmtpClient(platform?.smtp)
+
+            await smtpClient.sendMail({
+                from: `${senderName} <${senderEmail}>`,
+                to: emails.join(','),
+                subject: emailSubject,
+                html: emailBody,
+            })
+        },
+        isSystemSmtpConfigured(): boolean {
+            return !isNil(system.get(AppSystemProp.SMTP_HOST)) && !isNil(system.get(AppSystemProp.SMTP_PORT)) && !isNil(system.get(AppSystemProp.SMTP_USERNAME)) && !isNil(system.get(AppSystemProp.SMTP_PASSWORD))
+        },
+    }
+}
+
+const getPlatform = async (platformId: string | undefined): Promise<Platform | null> => {
+    return platformId ? platformService.getOne(platformId) : null
+}
+
+const renderEmailBody = async ({ platform, templateData }: RenderEmailBodyArgs): Promise<string> => {
+    const templatePath = `packages/server/api/src/assets/emails/promptx/${templateData.name}.html`
+    const template = await readFile(templatePath, 'utf-8')
+    const primaryColor = platform?.primaryColor ?? defaultTheme.colors.primary.default
+    const fullLogoUrl = platform?.fullLogoUrl ?? defaultTheme.logos.fullLogoUrl
+    const platformName = platform?.name ?? defaultTheme.websiteName
+
+    return Mustache.render(template, {
+        ...templateData.vars,
+        primaryColor,
+        fullLogoUrl,
+        platformName,
+    },
+    )
+}
+
+const initSmtpClient = (smtp: SMTPInformation | undefined | null): Transporter => {
+    const smtpPort = smtp?.port ?? Number.parseInt(system.getOrThrow(AppSystemProp.SMTP_PORT))
+    return nodemailer.createTransport({
+        host: smtp?.host ?? system.getOrThrow(AppSystemProp.SMTP_HOST),
+        port: smtpPort,
+        secure: smtpPort === 465,
+        auth: {
+            user: smtp?.user ?? system.getOrThrow(AppSystemProp.SMTP_USERNAME),
+            pass: smtp?.password ?? system.getOrThrow(AppSystemProp.SMTP_PASSWORD),
+        },
+    })
+}
+
+const getEmailSubject = (templateName: EmailTemplateData['name'], _vars: Record<string, string>): string => {
+    const templateToSubject: Record<EmailTemplateData['name'], string> = {
+        'invitation-email': 'You have been invited to a project',
+    }
+
+    return templateToSubject[templateName]
+}
+
+type RenderEmailBodyArgs = {
+    platform: Platform | null
+    templateData: EmailTemplateData
+}

--- a/packages/server/api/src/assets/emails/promptx/invitation-email.html
+++ b/packages/server/api/src/assets/emails/promptx/invitation-email.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="x-ua-compatible" content="ie=edge" />
+        <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+        <title>You're Invited to a PromptX Project</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </head>
+    <body style="margin: 0; padding: 0; background-color: #f5f5f5;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: #f5f5f5;">
+            <tr>
+                <td align="center" style="padding: 40px 0;">
+                    <table role="presentation" width="500" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 500px; background-color: #ffffff; border-radius: 12px; box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);">
+                        <tr>
+                            <td style="padding: 30px; font-family: Arial, sans-serif;">
+                                <!-- Logo -->
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                                    <tr>
+                                        <td align="left" style="padding-bottom: 20px;">
+                                            <img src="https://promptxai.com/promptx/images/logo.svg" alt="PromptX Logo" style="height: 24px;" />
+                                        </td>
+                                    </tr>
+                                </table>
+
+                                <!-- Header -->
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                                    <tr>
+                                        <td style="font-size: 20px; color: #202020; font-weight: bold; padding-bottom: 10px;">
+                                            You are invited to collaborate on the AutomationX project: “{{projectOrPlatformName}}”
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td style="font-size: 14px; color: #202020; line-height: 1.6; padding-bottom: 10px;">
+                                            You’ve been invited to join this project on AutomationX. Click the button below to accept the invitation and access the project.
+                                        </td>
+                                    </tr>
+                                </table>
+
+                                <!-- Button -->
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                                    <tr>
+                                        <td align="center" style="padding: 20px 0;">
+                                            <a
+                                                href="{{invitationLink}}"
+                                                style="
+                                                    display: inline-block;
+                                                    width: 100%;
+                                                    background-color: #254c7e;
+                                                    color: #ffffff;
+                                                    text-decoration: none;
+                                                    padding: 14px 0;
+                                                    border-radius: 24px;
+                                                    font-weight: bold;
+                                                    font-size: 14px;
+                                                    text-align: center;
+                                                "
+                                            >
+                                                Accept Invitation
+                                            </a>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td style="font-size: 14px; color: #646464; text-align: left;">
+                                            This invitation link is valid for 24 hours and can only be used once.
+                                        </td>
+                                    </tr>
+                                </table>
+
+                                <!-- Divider -->
+                                <br />
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                                    <tr>
+                                        <td style="border-top: 1px solid #e0e0e0; padding: 20px 0px 0px;"></td>
+                                    </tr>
+                                </table>
+
+                                <!-- Footer -->
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                                    <tr>
+                                        <td style="font-size: 12px; color: #888888;">
+                                            <img src="https://promptxai.com/promptx/images/logo.svg" alt="PromptX Logo" style="height: 20px; margin-bottom: 8px;" /><br />
+                                            © 2022 Avalant Company Limited. All rights reserved.<br />
+                                            Building 15 Floor, Bubhajit, 20 N Sathorn Rd,<br />
+                                            Silom, Bang Rak, Bangkok 10500
+                                        </td>
+                                    </tr>
+                                </table>
+
+                                <!-- Divider -->
+                                <br />
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                                    <tr>
+                                        <td style="border-top: 1px solid #e0e0e0; padding: 20px 0 0;"></td>
+                                    </tr>
+                                </table>
+
+                                <!-- Footer Links -->
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                                    <tr>
+                                        <td align="left" style="font-size: 12px;">
+                                            <a href="https://www.promptxai.com" style="color: #1e428b; text-decoration: none;">www.promptxai.com</a>
+                                        </td>
+                                        <td align="right" style="font-size: 12px;">
+                                            <a href="https://promptxai.com/promptx/contact.html" style="color: #1e428b; text-decoration: none;">Contact Us</a>
+                                            &nbsp;&nbsp;&nbsp;
+                                            <a href="https://promptxai.com/promptx/privacy.html" style="color: #1e428b; text-decoration: none;">Privacy Policy</a>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </body>
+</html>


### PR DESCRIPTION
### What does this PR do?
- Re-use the SMTP / node mailer packages in upstream code to leverage sendgrid's SMTP relay
- New invitation email template

Notes
- Images / icons don't work in gmail as they are not served from the same domain (need to fix)
- Currently not integrated with invitation flow because of the aforementioned issue
