### PR TITLE
fix: enable project members in getUsersForProject to list todo assignees correctly

### DIFF
--- a/packages/server/api/src/app/project-member/project-member.service.ts
+++ b/packages/server/api/src/app/project-member/project-member.service.ts
@@ -5,13 +5,13 @@ import { paginationHelper } from '../helper/pagination/pagination-utils'
 import { projectService } from '../project/project-service'
 import { ProjectMemberEntity } from './project-member.entity'
 
-const repo = repoFactory(ProjectMemberEntity)
+export const projectMemberRepo = repoFactory(ProjectMemberEntity)
 
 export const projectMemberService = {
     async upsert({ userId, projectId, projectRoleId }: UpsertParams): Promise<ProjectMember> {
         const { platformId } = await projectService.getOneOrThrow(projectId)
 
-        const existingMember = await repo().findOneBy({
+        const existingMember = await projectMemberRepo().findOneBy({
             userId,
             projectId,
             platformId,
@@ -27,20 +27,20 @@ export const projectMemberService = {
             projectRoleId,
         }
 
-        await repo().upsert(member, [
+        await projectMemberRepo().upsert(member, [
             'projectId',
             'userId',
             'platformId',
         ])
 
-        return repo().findOneOrFail({
+        return projectMemberRepo().findOneOrFail({
             where: {
                 id: memberId,
             },
         })
     },
     async delete({ projectId, projectMemberId }: DeleteParams): Promise<void> {
-        await repo().delete({ projectId, id: projectMemberId })
+        await projectMemberRepo().delete({ projectId, id: projectMemberId })
     },
     async list(
         {
@@ -61,7 +61,7 @@ export const projectMemberService = {
                 beforeCursor: decodedCursor.previousCursor,
             },
         })
-        const queryBuilder = repo()
+        const queryBuilder = projectMemberRepo()
             .createQueryBuilder('project_member')
             .where({ platformId })
 
@@ -78,7 +78,7 @@ export const projectMemberService = {
         return paginationHelper.createPage<ProjectMember>(data, cursor)
     },
     async getAuthorizedProjectIds(params: { platformId: string, userId: string }): Promise<string[]> {
-        const projectMembers = await repo().findBy({
+        const projectMembers = await projectMemberRepo().findBy({
             userId: params.userId,
             platformId: params.platformId,
         })

--- a/packages/server/api/src/app/user/user-service.ts
+++ b/packages/server/api/src/app/user/user-service.ts
@@ -23,6 +23,7 @@ import { buildPaginator } from '../helper/pagination/build-paginator'
 import { paginationHelper } from '../helper/pagination/pagination-utils'
 import { system } from '../helper/system/system'
 import { platformService } from '../platform/platform.service'
+import { projectMemberRepo } from '../project-member/project-member.service'
 import { UserEntity, UserSchema } from './user-entity'
 
 
@@ -174,13 +175,16 @@ export const userService = {
 
 async function getUsersForProject(platformId: PlatformId, projectId: string) {
     const platformAdmins = await userRepo().find({ where: { platformId, platformRole: PlatformRole.ADMIN } }).then((users) => users.map((user) => user.id))
-    const edition = system.getEdition()
-    if (edition === ApEdition.COMMUNITY) {
-        return platformAdmins
-    }
+    // const edition = system.getEdition()
+    // if (edition === ApEdition.COMMUNITY) {
+    //     return platformAdmins
+    // }
     // const projectMembers = await projectMemberRepo().find({ where: { projectId, platformId } }).then((members) => members.map((member) => member.userId))
     // return [...platformAdmins, ...projectMembers]
-    return platformAdmins
+    // return platformAdmins
+
+    const projectMembers = await projectMemberRepo().find({ where: { projectId, platformId } }).then((members) => members.map((member) => member.userId))
+    return [...platformAdmins, ...projectMembers]
 }
 
 type ListUsersForProjectParams = {


### PR DESCRIPTION
### What does this PR do?
- As the title says (missed it during feature rollout)
