### PR TITLE
feat: introduce builder AI module spike

### DIFF
--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -17,6 +17,7 @@ import { userOAuth2Service } from './app-connection/app-connection-service/oauth
 import { appConnectionModule } from './app-connection/app-connection.module'
 import { appEventRoutingModule } from './app-event-routing/app-event-routing.module'
 import { authenticationModule } from './authentication/authentication.module'
+import { builderModule } from './builder/builder.module'
 import { changelogModule } from './changelog/changelog.module'
 import { copilotModule } from './copilot/copilot.module'
 import { rateLimitModule } from './core/security/rate-limit'
@@ -233,6 +234,7 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
     await app.register(projectMemberModule)
 
     await app.register(agentRunsModule)
+    await app.register(builderModule)
 
     app.get(
         '/redirect',

--- a/packages/server/api/src/app/builder/builder.html
+++ b/packages/server/api/src/app/builder/builder.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Workflow Chat UI</title>
+  <style>
+    body {
+      display: flex;
+      height: 100vh;
+      margin: 0;
+      font-family: sans-serif;
+    }
+
+    #flow-pane {
+      width: 40%;
+      padding: 16px;
+      border-right: 1px solid #ccc;
+      overflow-y: auto;
+    }
+
+    #chat-pane {
+      width: 60%;
+      display: flex;
+      flex-direction: column;
+      padding: 16px;
+    }
+
+    #chat-history {
+      flex-grow: 1;
+      overflow-y: auto;
+      border: 1px solid #ddd;
+      padding: 8px;
+      margin-bottom: 8px;
+      background: #f9f9f9;
+    }
+
+    .message {
+      margin-bottom: 6px;
+    }
+
+    .user {
+      font-weight: bold;
+      color: #007bff;
+    }
+
+    .bot {
+      color: #333;
+    }
+
+    form {
+      display: flex;
+      gap: 8px;
+    }
+
+    input[type="text"] {
+      flex-grow: 1;
+      padding: 8px;
+    }
+
+    button {
+      padding: 8px 12px;
+    }
+  </style>
+</head>
+<body>
+  <div id="flow-pane">
+    <h3>Workflow View</h3>
+    <pre id="workflow-data">Loading...</pre>
+  </div>
+
+  <div id="chat-pane">
+    <h3>Workflow Chat</h3>
+    <div id="chat-history"></div>
+    <form id="chat-form">
+      <input type="text" id="user-input" placeholder="Type your message..." required />
+      <button type="submit">Send</button>
+    </form>
+  </div>
+
+  <script>
+    const AUTH_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjEifQ.eyJpZCI6IkxMcVZQVHlNdE1zWVprNWM1WDZIZCIsInR5cGUiOiJVU0VSIiwicHJvamVjdElkIjoibkZDSW1xMU9IbFJnS1dVVTV5Zm9mIiwicGxhdGZvcm0iOnsiaWQiOiJIR2tBbDJkQjNVUVBCUXlmY1NPTWIifSwidG9rZW5WZXJzaW9uIjoiaFpLalNXaU5RVnZiazh2UHVUdXlmIiwiaWF0IjoxNzU2MTc2OTkxLCJleHAiOjE3NTY3ODE3OTEsImlzcyI6ImFjdGl2ZXBpZWNlcyJ9.LtGUJCvuxdgH62JOVuyjizPWxYZqgXOIPnx4PxGZueY';
+    const workflowUrl = 'http://localhost:4200/api/v1/flows/IdRtZA6Mc1HoVuU3Ag7D9';
+    const chatUrl = 'http://localhost:4200/api/v1/builder/flow/IdRtZA6Mc1HoVuU3Ag7D9';
+
+    const workflowDataEl = document.getElementById('workflow-data');
+    const chatHistoryEl = document.getElementById('chat-history');
+    const chatForm = document.getElementById('chat-form');
+    const userInput = document.getElementById('user-input');
+
+    // In-memory conversation history for sending to backend
+    let messages = [];
+
+    // Load workflow data (GET)
+    async function loadWorkflow() {
+      try {
+        const res = await fetch(workflowUrl, {
+          headers: {
+            'Authorization': `Bearer ${AUTH_TOKEN}`
+          }
+        });
+        const data = await res.json();
+        workflowDataEl.textContent = JSON.stringify(data, null, 2);
+      } catch (err) {
+        workflowDataEl.textContent = 'Error loading workflow data';
+      }
+    }
+
+    // Append message to chat
+    function appendMessage(sender, text) {
+      const msgEl = document.createElement('div');
+      msgEl.className = `message ${sender}`;
+      msgEl.textContent = `${sender === 'user' ? 'You' : 'Bot'}: ${text}`;
+      chatHistoryEl.appendChild(msgEl);
+      chatHistoryEl.scrollTop = chatHistoryEl.scrollHeight;
+    }
+
+    // Handle chat form submission (POST)
+    chatForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const message = userInput.value;
+      userInput.value = '';
+
+      // Add to UI
+      appendMessage('user', message);
+
+      // Add to messages array
+      messages.push({ role: 'user', content: message });
+
+      try {
+        const res = await fetch(chatUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${AUTH_TOKEN}`
+          },
+          body: JSON.stringify({
+            messages: messages  // Send full conversation
+          }),
+        });
+
+        const data = await res.text();
+
+        // Decide where the assistant's reply comes from
+        const botReply = data || 'No reply';
+        appendMessage('bot', botReply);
+
+        // Add assistant reply to messages array
+        messages.push({ role: 'assistant', content: botReply });
+
+      } catch (err) {
+        console.log(err);
+        appendMessage('bot', 'Error connecting to backend.');
+      }
+
+      await loadWorkflow(); // Refresh workflow view after message
+    });
+
+    // Initial load
+    loadWorkflow();
+  </script>
+</body>
+</html>

--- a/packages/server/api/src/app/builder/builder.module.ts
+++ b/packages/server/api/src/app/builder/builder.module.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs'
+import { PrincipalType } from '@activepieces/shared'
+import { FastifyPluginAsyncTypebox, Type } from '@fastify/type-provider-typebox'
+import { StatusCodes } from 'http-status-codes'
+import { builderService } from './builder.service'
+
+
+export const builderModule: FastifyPluginAsyncTypebox = async (app) => {
+    await app.register(builderController, { prefix: '/v1/builder' })
+}
+
+const builderController: FastifyPluginAsyncTypebox = async (app) => {
+    app.get('/', BuilderRequestParams, async () => {
+        const filePath  = 'packages/server/api/src/app/builder/builder.html'
+        const stream = fs.createReadStream(filePath, 'utf8')
+        return stream
+    })
+
+    app.post('/flow/:id', UpdateBuilderFlowRequestParams, async (request) => {
+        const platformId = request.principal.platform.id
+        const projectId = request.principal.projectId
+        const userId = request.principal.id
+        const { messages } = request.body
+        request.log.info({ messages }, 'messages')
+        const result = await builderService(request.log).runAndUpdate({
+            userId,
+            projectId,
+            platformId,
+            flowId: request.params.id,
+            messages,
+        })
+        // request.log.info({ steps: result.steps }, 'execution steps')
+        return result.text
+    })
+}
+
+const UpdateBuilderFlowRequest = Type.Object({
+    messages: Type.Array(Type.Object({
+        role: Type.Union([Type.Literal('assistant'), Type.Literal('user')]),
+        content: Type.String(),
+    }))
+})
+
+const UpdateBuilderFlowRequestParams = {
+    schema: {
+        body: UpdateBuilderFlowRequest,
+        params: Type.Object({
+            id: Type.String(),
+        }),
+        response: {
+            [StatusCodes.CREATED]: Type.Any(),
+        },
+    },
+    config: {
+        allowedPrincipals: [PrincipalType.USER],
+    },
+}
+
+const BuilderRequestParams = {
+    config: {
+        allowedPrincipals: [PrincipalType.UNKNOWN],
+    },
+}

--- a/packages/server/api/src/app/builder/builder.service.ts
+++ b/packages/server/api/src/app/builder/builder.service.ts
@@ -1,0 +1,167 @@
+import { AIUsageFeature, createAIModel } from '@activepieces/common-ai'
+import {
+    assertNotNullOrUndefined,
+    FlowAction,
+    flowStructureUtil,
+    FlowTrigger,
+    FlowVersion,
+    FlowVersionState,
+} from '@activepieces/shared'
+import { openai } from '@ai-sdk/openai'
+import { generateText, GenerateTextResult, stepCountIs } from 'ai'
+import { FastifyBaseLogger } from 'fastify'
+import { accessTokenManager } from '../authentication/lib/access-token-manager'
+import { flowService } from '../flows/flow/flow.service'
+import { flowVersionService } from '../flows/flow-version/flow-version.service'
+import { domainHelper } from '../helper/domain-helper'
+import { buildBuilderTools } from './builder.tools'
+
+/*
+ * Strips a FlowVersion of unnecessary metadata before sending it to the AI model.
+ * The goal is to reduce token usage and prevent the model from being distracted
+ * by attributes it doesn’t need to know in order to reason about the flow.
+ *
+ * Example of final stripped format:
+ *
+ * {
+ *   "displayName": "test",
+ *   "trigger": {
+ *     "name": "trigger",
+ *     "type": "PIECE_TRIGGER",
+ *     "valid": false,
+ *     "settings": {
+ *       "pieceName": "@activepieces/piece-slack",
+ *       "triggerName": "new-message",
+ *       "pieceVersion": "~0.10.2"
+ *     },
+ *     "nextAction": {
+ *       "name": "send_email",
+ *       "type": "PIECE",
+ *       "settings": {
+ *         "pieceName": "@activepieces/piece-gmail",
+ *         "actionName": "send_email",
+ *         "pieceVersion": "~0.8.4"
+ *       },
+ *       "nextAction": {
+ *         "name": "send_request",
+ *         "type": "PIECE",
+ *         "settings": {
+ *           "pieceName": "@activepieces/piece-http",
+ *           "actionName": "send_request",
+ *           "pieceVersion": "~0.8.4"
+ *         }
+ *       }
+ *     }
+ *   }
+ * }
+ */
+const stripFlowVersionForAiPrompt = (flowVersion: FlowVersion): string => {
+    // Traverse the flow structure and clean each step
+    const minimalFlowVersion = flowStructureUtil.transferFlow(flowVersion, (step) => {
+        const cleaned = { ...step }
+
+        // Remove unneeded step settings metadata
+        if (cleaned.settings) {
+            delete cleaned.settings.errorHandlingOptions
+            delete cleaned.settings.inputUiInfo
+            delete cleaned.settings.connectionIds
+            delete cleaned.settings.agentIds
+            delete cleaned.settings.input
+            delete cleaned.settings.inputUiInfo // duplicate remove to be safe
+        }
+
+        // Remove extra fields from triggers
+        if (flowStructureUtil.isTrigger(cleaned.type)) {
+            delete (cleaned as Partial<FlowTrigger>).displayName
+        }
+
+        // Remove extra fields from actions
+        if (flowStructureUtil.isAction(cleaned.type)) {
+            delete (cleaned as Partial<FlowAction>).valid
+            delete (cleaned as Partial<FlowAction>).displayName
+        }
+
+        return cleaned
+    })
+
+    // Remove top-level metadata that’s irrelevant to the AI
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id, created, updated, flowId, connectionIds, agentIds, updatedBy, valid, state, schemaVersion, ...rest } = minimalFlowVersion
+
+    // Return as pretty-printed JSON for easier reading in the prompt
+    return JSON.stringify(rest, null, 2)
+}
+
+
+export const builderService = (log: FastifyBaseLogger) => ({
+    async runAndUpdate({ userId, projectId, platformId, flowId, messages }: RunParams): Promise<GenerateTextResult<ReturnType<typeof buildBuilderTools>, string>> {
+        await flowService(log).getOneOrThrow({
+            projectId,
+            id: flowId,
+        })
+        const flowVersion = await flowVersionService(log).getLatestVersion(flowId, FlowVersionState.DRAFT)
+        assertNotNullOrUndefined(flowVersion, 'No draft flow version found')
+
+        const engineToken = await accessTokenManager.generateEngineToken({
+            projectId,
+            platformId,
+        })
+        const baseURL = await domainHelper.getPublicApiUrl({ path: '/v1/ai-providers/proxy/openai', platformId })
+        const system = `You are a workflow builder agent.
+
+            A workflow or "flow" consists of "steps" which integrate to external services called "pieces".
+            A piece can have multiple triggers and actions.
+            A flow consists of one trigger step and multiple action steps beneath it.
+            A flow is represented in JSON format.
+            A trigger step should always be named "trigger" whereas action step names must be unique in a flow and simple (ex. "step_1", "step_2" etc)
+
+            You have been provided with atomic tools to modify a flow by updating trigger and action steps.
+
+            Here's what you should do
+            1. User may not provide fully qualified piece names, so you should first find pieceName and pieceVersion using the "list-pieces" tool
+            2. To find the correct actionName or triggerName for a given pieceName, use the "get-piece-information" tool
+            3. Identify where to add the required action by asking the user the "parentStepName" used in "add-action" tool
+
+            Important: If you're unsure of a pieceName, triggerName or parentStepName - please ask the user
+            `
+        const systemWithFlowPrompt = `
+            ${system}
+
+            Here's the current flow:
+
+            ${stripFlowVersionForAiPrompt(flowVersion)}
+            `
+        const model = createAIModel({
+            providerName: 'openai',
+            modelInstance: openai('gpt-4.1'),
+            engineToken,
+            baseURL,
+            metadata: {
+                feature: AIUsageFeature.TEXT_AI,
+            },
+        })
+        const result = await generateText({
+            model,
+            stopWhen: stepCountIs(10),
+            messages: [
+                { role: 'system', content: systemWithFlowPrompt },
+                ...messages,
+            ],
+            tools: buildBuilderTools({ userId, projectId, platformId, flowId, flowVersionId: flowVersion.id }),
+        })
+        return result
+    },
+})
+
+type ChatMessage = {
+    role: 'system' | 'user' | 'assistant'
+    content: string
+}
+
+type RunParams = {
+    userId: string
+    projectId: string
+    platformId: string
+    flowId: string
+    messages: ChatMessage[]
+}

--- a/packages/server/api/src/app/builder/builder.tools.ts
+++ b/packages/server/api/src/app/builder/builder.tools.ts
@@ -1,0 +1,374 @@
+import { PieceMetadataModel, PieceMetadataModelSummary } from '@activepieces/pieces-framework'
+import { apVersionUtil } from '@activepieces/server-shared'
+import {
+    AddActionRequest,
+    ApEdition,
+    assertNotNullOrUndefined,
+    DeleteActionRequest,
+    FlowActionType,
+    FlowOperationRequest,
+    FlowOperationType,
+    FlowTrigger,
+    FlowTriggerType,
+    LocalesEnum,
+    PieceTrigger,
+    StepLocationRelativeToParent,
+    UpdateActionRequest,
+} from '@activepieces/shared'
+import { Tool, tool } from 'ai'
+import { z } from 'zod'
+import { flowService } from '../flows/flow/flow.service'
+import { flowVersionService } from '../flows/flow-version/flow-version.service'
+import { system } from '../helper/system/system'
+import { pieceMetadataService } from '../pieces/piece-metadata-service'
+
+const log = system.globalLogger()
+
+type CommonOperationParams = {
+    userId: string
+    projectId: string
+    platformId: string
+    flowId: string
+    flowVersionId: string
+}
+
+type SaveFlowVersionParams = CommonOperationParams & {
+    operation: FlowOperationRequest
+}
+
+const applyAndSaveFlowVersion = async (params: SaveFlowVersionParams): Promise<void> => {
+    const { userId, projectId, platformId, flowId, operation } = params
+    await flowService(log).update({
+        id: flowId,
+        userId,
+        platformId,
+        projectId,
+        operation,
+    })
+}
+
+type GetAllBuilderPieceParams = {
+    searchQuery?: string
+}
+
+const getAllPiecesSummary =  async (params: GetAllBuilderPieceParams): Promise<PieceMetadataModelSummary[]> => {
+    const latestRelease = await apVersionUtil.getCurrentRelease()
+    const pieces = await pieceMetadataService(log).list({
+        includeTags: false,
+        includeHidden: false,
+        searchQuery: params.searchQuery,
+        release: latestRelease,
+        edition: ApEdition.COMMUNITY,
+        locale: LocalesEnum.ENGLISH,
+    })
+    // Take first 5 matches and remove i18n translations
+    return pieces.map((piece) => ({ ...piece, i18n: undefined })).slice(0, 5)
+}
+
+type GetBuilderPieceParams = {
+    platformId: string
+    projectId: string
+    name: string
+    version: string | undefined
+}
+
+const getPieceMetadataByName = async (params: GetBuilderPieceParams): Promise<PieceMetadataModel> => {
+    const piece = await pieceMetadataService(log).getOrThrow({
+        ...params,
+        locale: LocalesEnum.ENGLISH,
+    })
+    return { ...piece, i18n: undefined }
+}
+
+type UpdateTriggerParams = CommonOperationParams & {
+    request: FlowTrigger
+}
+
+const updateTrigger = async (params: UpdateTriggerParams): Promise<void> => {
+    const flowVersion = await flowVersionService(log).getOne(params.flowVersionId)
+    assertNotNullOrUndefined(flowVersion, 'flow version not found')
+
+    const operation: FlowOperationRequest = {
+        type: FlowOperationType.UPDATE_TRIGGER,
+        request: params.request,
+    }
+
+    await applyAndSaveFlowVersion({
+        userId: params.userId,
+        projectId: params.projectId,
+        platformId: params.platformId,
+        flowId: params.flowId,
+        flowVersionId: params.flowVersionId,
+        operation,
+    })
+}
+
+type AddActionParams = CommonOperationParams & {
+    request: AddActionRequest
+}
+
+const addAction = async (params: AddActionParams): Promise<void> => {
+    const flowVersion = await flowVersionService(log).getOne(params.flowVersionId)
+    assertNotNullOrUndefined(flowVersion, 'flow version not found')
+
+    const operation: FlowOperationRequest = {
+        type: FlowOperationType.ADD_ACTION,
+        request: params.request,
+    }
+
+    await applyAndSaveFlowVersion({
+        userId: params.userId,
+        projectId: params.projectId,
+        platformId: params.platformId,
+        flowId: params.flowId,
+        flowVersionId: params.flowVersionId,
+        operation,
+    })
+}
+
+type UpdateActionParams = CommonOperationParams & {
+    request: UpdateActionRequest
+}
+
+const updateAction = async (params: UpdateActionParams): Promise<void> => {
+    const flowVersion = await flowVersionService(log).getOne(params.flowVersionId)
+    assertNotNullOrUndefined(flowVersion, 'flow version not found')
+
+    const operation: FlowOperationRequest = {
+        type: FlowOperationType.UPDATE_ACTION,
+        request: params.request,
+    }
+
+    await applyAndSaveFlowVersion({
+        userId: params.userId,
+        projectId: params.projectId,
+        platformId: params.platformId,
+        flowId: params.flowId,
+        flowVersionId: params.flowVersionId,
+        operation,
+    })
+}
+
+type RemoveActionParams = CommonOperationParams & {
+    request: DeleteActionRequest
+}
+
+const removeAction = async (params: RemoveActionParams): Promise<void> => {
+    const flowVersion = await flowVersionService(log).getOne(params.flowVersionId)
+    assertNotNullOrUndefined(flowVersion, 'flow version not found')
+
+    const operation: FlowOperationRequest = {
+        type: FlowOperationType.DELETE_ACTION,
+        request: params.request,
+    }
+
+    await applyAndSaveFlowVersion({
+        userId: params.userId,
+        projectId: params.projectId,
+        platformId: params.platformId,
+        flowId: params.flowId,
+        flowVersionId: params.flowVersionId,
+        operation,
+    })
+}
+
+export const builderOperations = {
+    updateTrigger,
+    addAction,
+    updateAction,
+    removeAction,
+}
+
+export const buildBuilderTools = ({ userId, projectId, platformId, flowId, flowVersionId }: BuilderParams): Record<string, Tool> => {
+    return {
+        'list-pieces': tool({
+            description: 'List all available pieces (and their names) with or without a search query',
+            inputSchema: z.object({
+                searchQuery: z.string().optional(),
+            }),
+            execute: async (params) => {
+                log.info(params, 'list-pieces')
+                return getAllPiecesSummary(params)
+            },
+        }),
+        'get-piece-information': tool({
+            description: 'Fetch information of a given piece including metadata, actions and triggers',
+            inputSchema: z.object({
+                pieceName: z.string(),
+            }),
+            execute: async ({ pieceName }) => {
+                log.info({ pieceName }, 'get-piece-information params')
+                if (!pieceName.startsWith('@')) {
+                    throw new Error('Invalid piece name. Piece names must begin with "@"')
+                }
+                return getPieceMetadataByName({
+                    projectId,
+                    platformId,
+                    name: pieceName,
+                    version: undefined,
+                })
+            },
+        }),
+        'update-trigger': tool({
+            description: 'update a flow trigger in workflow',
+            inputSchema: z.object({
+                pieceName: z.string(),
+                pieceVersion: z.string(),
+                pieceTriggerName: z.string(),
+            }),
+            execute: async ({ pieceName, pieceVersion, pieceTriggerName }) => {
+                log.info({ flowVersionId, pieceName, pieceVersion, pieceTriggerName }, 'create-trigger params')
+                if (!pieceName.startsWith('@')) {
+                    throw new Error('Invalid piece name. Piece names must begin with "@"')
+                }
+                const request: PieceTrigger = {
+                    name: 'trigger',
+                    valid: true,
+                    displayName: pieceTriggerName,
+                    type: FlowTriggerType.PIECE,
+                    settings: {
+                        pieceName,
+                        pieceVersion,
+                        input: {},
+                        inputUiInfo: {
+                            customizedInputs: {},
+                        },
+                        triggerName: pieceTriggerName.toLowerCase().replace(' ', '-'),
+                    },
+                }
+                await builderOperations.updateTrigger({
+                    userId,
+                    projectId,
+                    platformId,
+                    flowId,
+                    flowVersionId,
+                    request,
+                })
+                log.info('updated version for create-trigger')
+                return {
+                    text: `updated flow with trigger ${pieceTriggerName}`,
+                }
+            },
+        }),
+        'add-action': tool({
+            description: 'create a flow action in the workflow',
+            inputSchema: z.object({
+                parentStepName: z.string({ description: 'Name of the parent node' }),
+                stepName: z.string({ description: 'Unique name of the step (step-1, step-2 etc' }),
+                pieceName: z.string(),
+                pieceVersion: z.string(),
+                pieceActionName: z.string(),
+            }),
+            execute: async (params) => {
+                log.info(params, 'add-action params')
+                const { parentStepName, stepName, pieceName, pieceVersion, pieceActionName } = params
+                if (!pieceName.startsWith('@')) {
+                    throw new Error('Invalid piece name. Piece names must begin with "@"')
+                }
+                const request: AddActionRequest = {
+                    parentStep: parentStepName,
+                    stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+                    action: {
+                        valid: true,
+                        type: FlowActionType.PIECE,
+                        name: stepName,
+                        displayName: pieceActionName,
+                        settings: {
+                            pieceName,
+                            pieceVersion,
+                            actionName: pieceActionName,
+                            input: {},
+                            inputUiInfo: {},
+                            errorHandlingOptions: {},
+                        },
+                    },
+                }
+                await builderOperations.addAction({
+                    userId,
+                    projectId,
+                    platformId,
+                    flowId,
+                    flowVersionId,
+                    request,
+                })
+                log.info('updated version for add-action')
+                return {
+                    text: `updated flow with action ${pieceActionName}`,
+                }
+            },
+        }),
+        'update-action': tool({
+            description: 'update or replace a flow action in the workflow',
+            inputSchema: z.object({
+                pieceName: z.string(),
+                pieceVersion: z.string(),
+                pieceActionName: z.string(),
+            }),
+            execute: async (params) => {
+                log.info(params, 'update-action params')
+                const { pieceName, pieceVersion, pieceActionName } = params
+                if (!pieceName.startsWith('@')) {
+                    throw new Error('Invalid piece name. Piece names must begin with "@"')
+                }
+                const request: UpdateActionRequest = {
+                    valid: true,
+                    type: FlowActionType.PIECE,
+                    name: pieceActionName,
+                    displayName: pieceActionName,
+                    settings: {
+                        pieceName,
+                        pieceVersion,
+                        actionName: pieceActionName,
+                        input: {},
+                        inputUiInfo: {},
+                        errorHandlingOptions: {},
+                    },
+                }
+                await builderOperations.updateAction({
+                    userId,
+                    projectId,
+                    platformId,
+                    flowId,
+                    flowVersionId,
+                    request,
+                })
+                log.info('updated version for update-action')
+                return {
+                    text: `updated flow with action ${pieceActionName}`,
+                }
+            },
+        }),
+        'remove-action': tool({
+            description: 'remove flow action from the workflow',
+            inputSchema: z.object({
+                actionNames: z.array(z.string()),
+            }),
+            execute: async ({ actionNames }) => {
+                log.info({ flowVersionId, actionNames }, 'remove-action params')
+                const request: DeleteActionRequest = {
+                    names: actionNames,
+                }
+                await builderOperations.removeAction({
+                    userId,
+                    projectId,
+                    platformId,
+                    flowId,
+                    flowVersionId,
+                    request,
+                })
+                log.info('updated version for remove-action')
+                return {
+                    text: `updated flow, removed actions ${actionNames}`,
+                }
+            },
+        }),
+    }
+}
+
+type BuilderParams = {
+    platformId: string
+    projectId: string
+    userId: string
+    flowId: string
+    flowVersionId: string
+}


### PR DESCRIPTION
### What does this PR do?
- Enable the builder AI module and demo frontend for development purposes
- Note that this can only run on dev mode / local (as frontend is served directly from server)

### How to run
- Add an openai provider (need an API key)
- Find your JWT token 
- Add it to `builder.html`
- Hit `http://localhost:4200/api/v1/builder`
