### PR TITLE
fix: flow builder doesn't refresh when flow is deleted from sidebar

### DIFF
--- a/packages/react-ui/src/app/components/sidebar/builder/flows-navigation.tsx
+++ b/packages/react-ui/src/app/components/sidebar/builder/flows-navigation.tsx
@@ -352,6 +352,11 @@ function FlowItem({ flow, isActive, onClick, refetch }: FlowItemProps) {
           onMoveTo={refetch}
           onDelete={() => {
             if (flowId === flow.id) {
+              // todo(Rupal): Remove this when invalidateFlowsQuery is fixed
+              queryClient.invalidateQueries({
+                queryKey: ['flow', flow.id],
+              });
+
               flowsHooks.invalidateFlowsQuery(queryClient);
             }
             refetch();


### PR DESCRIPTION
### What does this PR do?
- As the title says
- Will sync with upstream when it is fixed there as well
