### PR TITLE
fix: improve explore page to improve loading speed and experience

### DIFF
--- a/packages/react-ui/src/app/routes/explore/index.tsx
+++ b/packages/react-ui/src/app/routes/explore/index.tsx
@@ -1,7 +1,6 @@
 import { t } from 'i18next';
 import { ArrowLeft, Search, SearchX } from 'lucide-react';
 import { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { CreateFlowWithAI } from '@/app/components/prompt-to-flow';
 import { ProjectDashboardPageHeader } from '@/app/components/project-layout/project-dashboard-page-header';
@@ -16,17 +15,14 @@ import {
 } from '@/components/ui/dialog';
 import {
   Empty,
-  EmptyContent,
   EmptyDescription,
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
 } from '@/components/ui/empty';
-import { LoadingSpinner } from '@/components/ui/spinner';
 import { TemplateDetailsView } from '@/features/templates/components/template-details-view';
 import { useTemplates } from '@/features/templates/hooks/templates-hook';
-import { userHooks } from '@/hooks/user-hooks';
-import { PlatformRole, Template, TemplateType } from '@activepieces/shared';
+import { Template, TemplateType } from '@activepieces/shared';
 import { AllCategoriesView } from '../templates/all-categories-view';
 
 export const ExplorePage = () => {
@@ -36,9 +32,6 @@ export const ExplorePage = () => {
   const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(
     null,
   );
-  const { data: user } = userHooks.useCurrentUser();
-  const navigate = useNavigate();
-  const isPlatformAdmin = user?.platformRole === PlatformRole.ADMIN;
 
   const templatesByCategory = useMemo(() => {
     const grouped: Record<string, Template[]> = {} as Record<
@@ -93,50 +86,34 @@ export const ExplorePage = () => {
           />
         </div>
 
-        {isLoading ? (
-          <div className="min-h-[300px] flex justify-center items-center">
-            <LoadingSpinner />
-          </div>
-        ) : (
-          <>
-            {filteredTemplates?.length === 0 && (
-              <Empty className="min-h-[300px]">
-                <EmptyHeader className="max-w-xl">
-                  <EmptyMedia variant="icon">
-                    <SearchX />
-                  </EmptyMedia>
-                  <EmptyTitle>{t('No templates found')}</EmptyTitle>
-                  <EmptyDescription>
-                    {search
-                      ? t(
-                          'No templates match your search criteria. Try adjusting your search terms.',
-                        )
-                      : t('No templates are available at the moment.')}
-                  </EmptyDescription>
-                </EmptyHeader>
-                {!search && isPlatformAdmin && (
-                  <EmptyContent>
-                    <Button
-                      onClick={() => navigate('/platform/setup/templates')}
-                    >
-                      {t('Setup Templates')}
-                    </Button>
-                  </EmptyContent>
-                )}
-              </Empty>
-            )}
-            <AllCategoriesView
-              templatesByCategory={templatesByCategory}
-              categories={categories}
-              onCategorySelect={() => {}}
-              onTemplateSelect={(template) => {
-                setSelectedTemplate(template);
-              }}
-              isLoading={isLoading}
-              hideHeader={true}
-            />
-          </>
+        {filteredTemplates.length === 0 && (
+          <Empty className="min-h-[300px]">
+            <EmptyHeader className="max-w-xl">
+              <EmptyMedia variant="icon">
+                <SearchX />
+              </EmptyMedia>
+              <EmptyTitle>{t('No templates found')}</EmptyTitle>
+              <EmptyDescription>
+                {search
+                  ? t(
+                      'No templates match your search criteria. Try adjusting your search terms.',
+                    )
+                  : t('No templates are available at the moment.')}
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
         )}
+
+        <AllCategoriesView
+          templatesByCategory={templatesByCategory}
+          categories={categories}
+          onCategorySelect={() => {}}
+          onTemplateSelect={(template) => {
+            setSelectedTemplate(template);
+          }}
+          isLoading={isLoading}
+          hideHeader={true}
+        />
       </div>
 
       <Dialog open={!!selectedTemplate} onOpenChange={unselectTemplate}>

--- a/packages/react-ui/src/app/routes/explore/index.tsx
+++ b/packages/react-ui/src/app/routes/explore/index.tsx
@@ -1,9 +1,8 @@
 import { t } from 'i18next';
 import { ArrowLeft, Search, SearchX } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { DashboardPageHeader } from '@/app/components/dashboard-page-header';
 import { CreateFlowWithAI } from '@/app/components/prompt-to-flow';
 import { ProjectDashboardPageHeader } from '@/app/components/project-layout/project-dashboard-page-header';
 import { InputWithIcon } from '@/components/custom/input-with-icon';
@@ -24,11 +23,11 @@ import {
   EmptyTitle,
 } from '@/components/ui/empty';
 import { LoadingSpinner } from '@/components/ui/spinner';
-import { TemplateCard } from '@/features/templates/components/template-card';
 import { TemplateDetailsView } from '@/features/templates/components/template-details-view';
 import { useTemplates } from '@/features/templates/hooks/templates-hook';
 import { userHooks } from '@/hooks/user-hooks';
 import { PlatformRole, Template, TemplateType } from '@activepieces/shared';
+import { AllCategoriesView } from '../templates/all-categories-view';
 
 export const ExplorePage = () => {
   const { filteredTemplates, isLoading, search, setSearch } = useTemplates({
@@ -40,6 +39,33 @@ export const ExplorePage = () => {
   const { data: user } = userHooks.useCurrentUser();
   const navigate = useNavigate();
   const isPlatformAdmin = user?.platformRole === PlatformRole.ADMIN;
+
+  const templatesByCategory = useMemo(() => {
+    const grouped: Record<string, Template[]> = {} as Record<
+      string,
+      Template[]
+    >;
+
+    grouped['All'] = [];
+
+    filteredTemplates.forEach((template: Template) => {
+      grouped['All'].push(template);
+      if (template.categories?.length) {
+        template.categories?.forEach((category: string) => {
+          if (!grouped[category]) {
+            grouped[category] = [];
+          }
+          grouped[category].push(template);
+        });
+      }
+    });
+
+    return grouped;
+  }, [filteredTemplates]);
+
+  const categories = useMemo(() => {
+    return Object.keys(templatesByCategory);
+  }, [templatesByCategory]);
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearch(event.target.value);
@@ -99,17 +125,16 @@ export const ExplorePage = () => {
                 )}
               </Empty>
             )}
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 pb-4">
-              {filteredTemplates?.map((template) => (
-                <TemplateCard
-                  key={template.id}
-                  template={template}
-                  onSelectTemplate={(template) => {
-                    setSelectedTemplate(template);
-                  }}
-                />
-              ))}
-            </div>
+            <AllCategoriesView
+              templatesByCategory={templatesByCategory}
+              categories={categories}
+              onCategorySelect={() => {}}
+              onTemplateSelect={(template) => {
+                setSelectedTemplate(template);
+              }}
+              isLoading={isLoading}
+              hideHeader={true}
+            />
           </>
         )}
       </div>

--- a/packages/react-ui/src/app/routes/templates/all-categories-view.tsx
+++ b/packages/react-ui/src/app/routes/templates/all-categories-view.tsx
@@ -1,0 +1,116 @@
+import { Template } from '@activepieces/shared';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { CategorySection } from './category-section';
+import { CategorySectionSkeleton } from './skeletons/category-section-skeleton';
+
+type AllCategoriesViewSkeletonProps = {
+  hideHeader?: boolean;
+};
+
+const AllCategoriesViewSkeleton = ({
+  hideHeader = false,
+}: AllCategoriesViewSkeletonProps) => {
+  return (
+    <div className="space-y-6">
+      {[...Array(4)].map((_, index) => (
+        <CategorySectionSkeleton key={index} hideHeader={hideHeader} />
+      ))}
+    </div>
+  );
+};
+
+function LazyCategorySection({
+  category,
+  templates,
+  onCategorySelect,
+  onTemplateSelect,
+}: {
+  category: string;
+  templates: Template[];
+  onCategorySelect: (category: string) => void;
+  onTemplateSelect: (template: Template) => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '200px' },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={ref}>
+      {isVisible ? (
+        <CategorySection
+          category={category}
+          templates={templates}
+          onCategorySelect={onCategorySelect}
+          onTemplateSelect={onTemplateSelect}
+        />
+      ) : (
+        <CategorySectionSkeleton />
+      )}
+    </div>
+  );
+}
+
+type AllCategoriesViewProps = {
+  templatesByCategory: Record<string, Template[]>;
+  categories: string[];
+  onCategorySelect: (category: string) => void;
+  onTemplateSelect: (template: Template) => void;
+  isLoading?: boolean;
+  hideHeader?: boolean;
+};
+
+export const AllCategoriesView = ({
+  templatesByCategory,
+  categories,
+  onCategorySelect,
+  onTemplateSelect,
+  isLoading = false,
+  hideHeader = false,
+}: AllCategoriesViewProps) => {
+  const stableOnCategorySelect = useCallback(onCategorySelect, [
+    onCategorySelect,
+  ]);
+  const stableOnTemplateSelect = useCallback(onTemplateSelect, [
+    onTemplateSelect,
+  ]);
+
+  if (isLoading) {
+    return <AllCategoriesViewSkeleton hideHeader={hideHeader} />;
+  }
+
+  return (
+    <div className="space-y-6">
+      {categories.map((category) => {
+        const categoryTemplates = templatesByCategory[category];
+
+        return (
+          <LazyCategorySection
+            key={category}
+            category={category}
+            templates={categoryTemplates}
+            onCategorySelect={stableOnCategorySelect}
+            onTemplateSelect={stableOnTemplateSelect}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/packages/react-ui/src/app/routes/templates/category-section.tsx
+++ b/packages/react-ui/src/app/routes/templates/category-section.tsx
@@ -42,10 +42,11 @@ export const CategorySection = React.memo(
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-xl font-medium">{category}</h2>
             <div className="flex items-center">
+              {/*todo(Rupal): button is hidden since we don't have a way to display all templates of a category on demand*/}
               <Button
                 variant="ghost"
                 onClick={() => onCategorySelect(category)}
-                className="flex items-center"
+                className="flex items-center hidden"
               >
                 {t('View all')}
               </Button>

--- a/packages/react-ui/src/app/routes/templates/category-section.tsx
+++ b/packages/react-ui/src/app/routes/templates/category-section.tsx
@@ -1,0 +1,88 @@
+import { Template } from '@activepieces/shared';
+import { t } from 'i18next';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import React from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '@/components/ui/carousel';
+import { TemplateCard } from '@/features/templates/components/template-card';
+
+type CategorySectionProps = {
+  category: string;
+  templates: Template[];
+  onCategorySelect: (category: string) => void;
+  onTemplateSelect: (template: Template) => void;
+};
+
+export const CategorySection = React.memo(
+  ({
+    category,
+    templates,
+    onCategorySelect,
+    onTemplateSelect,
+  }: CategorySectionProps) => {
+    if (!templates || templates.length === 0) return null;
+
+    return (
+      <div className="space-y-4">
+        <Carousel
+          opts={{
+            align: 'start',
+            loop: false,
+            slidesToScroll: 'auto',
+          }}
+          className="w-full"
+        >
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-medium">{category}</h2>
+            <div className="flex items-center">
+              <Button
+                variant="ghost"
+                onClick={() => onCategorySelect(category)}
+                className="flex items-center"
+              >
+                {t('View all')}
+              </Button>
+              <div className="flex items-center">
+                <CarouselPrevious
+                  variant="ghost"
+                  className="static translate-y-0 h-8 w-8"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </CarouselPrevious>
+                <CarouselNext
+                  variant="ghost"
+                  className="static translate-y-0 h-8 w-8"
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </CarouselNext>
+              </div>
+            </div>
+          </div>
+
+          <CarouselContent className="pb-3">
+            {templates.map((template) => (
+              <CarouselItem
+                key={template.id}
+                className="basis-full sm:basis-1/3 lg:basis-1/4 xl:basis-1/5 min-w-[320px]"
+              >
+                <TemplateCard
+                  template={template}
+                  onSelectTemplate={onTemplateSelect}
+                />
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+        </Carousel>
+      </div>
+    );
+  },
+);
+
+CategorySection.displayName = 'CategorySection';

--- a/packages/react-ui/src/app/routes/templates/skeletons/category-section-skeleton.tsx
+++ b/packages/react-ui/src/app/routes/templates/skeletons/category-section-skeleton.tsx
@@ -1,0 +1,50 @@
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+} from '@/components/ui/carousel';
+import { Skeleton } from '@/components/ui/skeleton';
+
+import { TemplateCardSkeleton } from './template-card-skeleton';
+
+type CategorySectionSkeletonProps = {
+  hideHeader?: boolean;
+};
+
+export const CategorySectionSkeleton = ({
+  hideHeader = false,
+}: CategorySectionSkeletonProps) => {
+  return (
+    <div className="space-y-4">
+      <Carousel
+        opts={{
+          align: 'start',
+          loop: false,
+        }}
+        className="w-full"
+      >
+        <div className="flex items-center justify-between mb-4">
+          <Skeleton className="h-8 w-48" />
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-8 w-20" />
+            <div className="flex items-center gap-1">
+              <Skeleton className="h-8 w-8 rounded-md" />
+              <Skeleton className="h-8 w-8 rounded-md" />
+            </div>
+          </div>
+        </div>
+
+        <CarouselContent className="pb-3">
+          {[...Array(4)].map((_, index) => (
+            <CarouselItem
+              key={index}
+              className="basis-full sm:basis-1/3 lg:basis-1/4 xl:basis-1/5 min-w-[350px]"
+            >
+              <TemplateCardSkeleton showCategoryCarouselButton={hideHeader} />
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+      </Carousel>
+    </div>
+  );
+};

--- a/packages/react-ui/src/app/routes/templates/skeletons/template-card-skeleton.tsx
+++ b/packages/react-ui/src/app/routes/templates/skeletons/template-card-skeleton.tsx
@@ -1,0 +1,41 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+type TemplateCardSkeletonProps = {
+  showCategoryCarouselButton?: boolean;
+};
+
+export const TemplateCardSkeleton = ({
+  showCategoryCarouselButton = false,
+}: TemplateCardSkeletonProps) => {
+  return (
+    <Card className="h-[250px] w-full flex flex-col">
+      <CardContent className="py-5 px-4 flex flex-col gap-1 flex-1 min-h-0">
+        {showCategoryCarouselButton && (
+          <div className="h-12 flex flex-col gap-2 flex-shrink-0">
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-5 w-3/4" />
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2 mt-1 flex-shrink-0">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+        </div>
+
+        <div className="h-8 flex gap-2 mt-1 flex-shrink-0">
+          <Skeleton className="h-6 w-20" />
+          <Skeleton className="h-6 w-24" />
+        </div>
+      </CardContent>
+
+      <div className="h-16 flex items-center px-4 rounded-b-lg">
+        <Skeleton className="h-8 w-8 rounded-full" />
+        <Skeleton className="h-8 w-8 rounded-full ml-2" />
+        <Skeleton className="h-8 w-8 rounded-full ml-2" />
+        <Skeleton className="h-8 w-8 rounded-full ml-2" />
+      </div>
+    </Card>
+  );
+};

--- a/packages/react-ui/src/features/templates/components/template-card.tsx
+++ b/packages/react-ui/src/features/templates/components/template-card.tsx
@@ -1,14 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import { t } from 'i18next';
-import { Info } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
 import { flowsApi } from '@/features/flows/lib/flows-api';
 import { foldersApi } from '@/features/folders/lib/folders-api';
 import { PieceIconList } from '@/features/pieces/components/piece-icon-list';
@@ -22,6 +16,7 @@ import {
 } from '@activepieces/shared';
 
 import { templatesApi } from '../lib/templates-api';
+import { Card } from '@/components/ui/card';
 
 type TemplateCardProps = {
   template: Template;
@@ -74,9 +69,11 @@ export const TemplateCard = ({
   });
 
   return (
-    <div
+    <Card
       key={template.id}
-      className="rounded-lg border border-solid border-dividers overflow-hidden"
+      variant={'interactive'}
+      className="h-[250px] w-full flex flex-col"
+      onClick={() => onSelectTemplate(template)}
     >
       <div className="flex items-center gap-2 p-4">
         <PieceIconList
@@ -96,30 +93,14 @@ export const TemplateCard = ({
       </p>
       <div className="py-2 px-4 gap-1 flex items-center">
         <Button
-          variant="default"
+          variant="outline"
           loading={isPending}
           className="px-2 h-8"
           onClick={() => createFlow(template)}
         >
           {t('Use Template')}
         </Button>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="size-10 flex justify-center items-center">
-              <Button
-                variant="ghost"
-                className="rounded-full p-3 hover:bg-muted cursor-pointer flex justify-center items-center"
-                onClick={() => onSelectTemplate(template)}
-              >
-                <Info className="w-4 h-4" />
-              </Button>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            <span className="text-sm">{t('Learn more')}</span>
-          </TooltipContent>
-        </Tooltip>
       </div>
-    </div>
+    </Card>
   );
 };

--- a/packages/react-ui/src/features/templates/components/template-card.tsx
+++ b/packages/react-ui/src/features/templates/components/template-card.tsx
@@ -84,7 +84,16 @@ export const TemplateCard = ({
           maxNumberOfIconsToShow={2}
         />
       </div>
-      <div className="text-sm font-medium px-4 min-h-16">{template.name}</div>
+      <div className="text-sm font-medium line-clamp-2 px-4 min-h-12">
+        {template.name}
+      </div>
+      <p className="text-muted-foreground text-sm line-clamp-3 px-4">
+        {template.summary ? (
+          template.summary
+        ) : (
+          <span className="italic">{t('No summary')}</span>
+        )}
+      </p>
       <div className="py-2 px-4 gap-1 flex items-center">
         <Button
           variant="default"

--- a/packages/react-ui/src/lib/utils.ts
+++ b/packages/react-ui/src/lib/utils.ts
@@ -10,6 +10,8 @@ import { LocalesEnum, Permission } from '@activepieces/shared';
 
 import { authenticationSession } from './authentication-session';
 
+export const DASHBOARD_CONTENT_PADDING_X = 'px-4';
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
### What does this PR do?
- Avoid loading all the templates on UI / Use template category as their respective section in a carousal view
- Improve the template card to display a chunk of template description
